### PR TITLE
Fix bug in plist handling

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -302,10 +302,10 @@ async function parseLocalizableStrings (caps) {
 
 async function getBundleIdFromApp (app) {
   logger.debug("Getting bundle ID from app");
-  let plist = path.resolve(app, "Info.plist");
+  let plistFile = path.resolve(app, "Info.plist");
   let obj;
   try {
-    obj = await plist.parsePlistFile(plist);
+    obj = await plist.parsePlistFile(plistFile);
   } catch (err) {
     logger.error("Could not get the bundleId from app.");
     throw err;
@@ -341,10 +341,10 @@ function shouldPrelaunchSimulator (caps, iosSdkVersion) {
 }
 
 async function setDeviceTypeInInfoPlist (app, deviceString) {
-  let plist = path.resolve(app, "Info.plist");
+  let plistFile = path.resolve(app, "Info.plist");
   let isiPhone = deviceString.toLowerCase().indexOf("ipad") === -1;
   let deviceTypeCode = isiPhone ? 1 : 2;
-  await plist.updatePlistFile(plist, {UIDeviceFamily: [deviceTypeCode]});
+  await plist.updatePlistFile(plistFile, {UIDeviceFamily: [deviceTypeCode]});
 }
 
 async function endSimulatorDaemons () {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "keywords": [
     "appium"
   ],
-  "version": "0.0.3",
+  "version": "0.0.4",
   "author": "appium",
   "license": "Apache-2.0",
   "repository": {


### PR DESCRIPTION
Clobbering the name `plist`, so function calls failed.