### PR TITLE
TravisCI - parellel tests

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,3 +1,4 @@
 node_modules
 *.log
 test/assets
+*.plist

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,5 +23,5 @@ before_script:
   - npm install -g mocha
 script:
   - gulp transpile
-  - mocha build/test/$TEST
+  - mocha build/test/$TEST -g @skip-ci -i
   - if [ -n "$FINAL_GULP" ]; then gulp $FINAL_GULP; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,12 @@
 sudo: required
+env:
+  # Run tests in parellel, up to 5 at once
+  - DEVICE=ios84 TEST=commands FINAL_GULP=coveralls
+  - DEVICE=ios84 TEST=e2e/testapp
+  - DEVICE=ios84 TEST=e2e/uicatalog
 language:
   - objective-c
+osx_image: xcode6.4
 before_install:
   # TavisCI's OSX environment gives us node 0.10.32
   # Use NVM to update it to 0.12
@@ -8,10 +14,14 @@ before_install:
   - git clone https://github.com/creationix/nvm.git ~/.nvm
   - source ~/.nvm/nvm.sh
   - nvm install 0.12
+  # Instruments fix:
+  # https://github.com/travis-ci/travis-ci/issues/4218
+  - ./instruments-auth.sh
 before_script:
   - npm install
   - npm install -g gulp
+  - npm install -g mocha
 script:
-  - npm test
-after_success:
-  - gulp coveralls
+  - gulp transpile
+  - mocha build/test/$TEST
+  - if [ -n "$FINAL_GULP" ]; then gulp $FINAL_GULP; fi

--- a/com.apple.dt.instruments.process.analysis.plist
+++ b/com.apple.dt.instruments.process.analysis.plist
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+        <key>allow-root</key>
+        <true/>
+        <key>authenticate-user</key>
+        <true/>
+        <key>class</key>
+        <string>user</string>
+        <key>comment</key>
+        <string>Rights for Instruments</string>
+        <key>created</key>
+        <real>409022991.255041</real>
+        <key>group</key>
+        <string>admin</string>
+        <key>identifier</key>
+        <string>com.apple.dt.instruments.dtsecurity.xpc</string>
+        <key>modified</key>
+        <real>409022991.255041</real>
+        <key>requirement</key>
+        <string>identifier "com.apple.dt.instruments.dtsecurity.xpc" and anchor apple</string>
+        <key>session-owner</key>
+        <false/>
+        <key>shared</key>
+        <true/>
+        <key>timeout</key>
+        <integer>36000</integer>
+        <key>tries</key>
+        <integer>10000</integer>
+        <key>version</key>
+        <integer>0</integer>
+</dict>
+</plist>

--- a/com.apple.dt.instruments.process.kill.plist
+++ b/com.apple.dt.instruments.process.kill.plist
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+        <key>allow-root</key>
+        <true/>
+        <key>authenticate-user</key>
+        <true/>
+        <key>class</key>
+        <string>user</string>
+        <key>comment</key>
+        <string>Rights for Instruments</string>
+        <key>created</key>
+        <real>409022991.27266097</real>
+        <key>group</key>
+        <string>admin</string>
+        <key>identifier</key>
+        <string>com.apple.dt.instruments.dtsecurity.xpc</string>
+        <key>modified</key>
+        <real>409022991.27266097</real>
+        <key>requirement</key>
+        <string>identifier "com.apple.dt.instruments.dtsecurity.xpc" and anchor apple</string>
+        <key>session-owner</key>
+        <false/>
+        <key>shared</key>
+        <true/>
+        <key>timeout</key>
+        <integer>5</integer>
+        <key>tries</key>
+        <integer>10000</integer>
+        <key>version</key>
+        <integer>0</integer>
+</dict>
+</plist>

--- a/instruments-auth.sh
+++ b/instruments-auth.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+sudo security authorizationdb write com.apple.dt.instruments.process.analysis <  com.apple.dt.instruments.process.analysis.plist
+sudo security authorizationdb write com.apple.dt.instruments.process.kill <  com.apple.dt.instruments.process.kill.plist


### PR DESCRIPTION
- Fixes TravisCI instruments issue.
- Runs TestApp and UICatalog tests side by side, takes ~30 mins total.

@imurchie 