### PR TITLE
Update base driver to get proxy methods

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   },
   "dependencies": {
     "adm-zip": "^0.4.7",
-    "appium-base-driver": "^1.0.2",
+    "appium-base-driver": "^1.1.0",
     "appium-cookies": "^1.0.0",
     "appium-express": "^1.0.0",
     "appium-instruments": "beta",


### PR DESCRIPTION
iOs doesn't proxy anything, but it needs the helper methods from `BaseDriver`.