### PR TITLE
Add plumbing for settings api, so tests don't fail

### DIFF
--- a/lib/driver.js
+++ b/lib/driver.js
@@ -1,4 +1,4 @@
-import { BaseDriver } from 'appium-base-driver';
+import { BaseDriver, DeviceSettings } from 'appium-base-driver';
 import utils from './utils';
 import logger from './logger';
 import path from 'path';
@@ -68,6 +68,8 @@ class IosDriver extends BaseDriver {
     this.keepAppToRetainPrefs = false;
     this.ready = false;
     this.asyncWaitMs = 0;
+
+    this.settings = new DeviceSettings({}, _.noop);
 
     this.locatorStrategies = ['xpath', 'id', 'name', 'class name', '-ios uiautomation',
       'accessibility id'];
@@ -900,7 +902,6 @@ class IosDriver extends BaseDriver {
   async adjustedDeviceName () {
     return await getDeviceString(this.opts);
   }
-
 }
 
 for (let [cmd, fn] of _.pairs(commands)) {


### PR DESCRIPTION
The base driver expects a `this.settings` property, or it fails. Even if the settings don't do anything.