### PR TITLE
Fix travis config after tests shifted

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 sudo: required
 env:
   # Run tests in parellel, up to 5 at once
-  - DEVICE=ios84 TEST=commands FINAL_GULP=coveralls
+  - DEVICE=ios84 FINAL_GULP=coveralls
   - DEVICE=ios84 TEST=e2e/testapp
   - DEVICE=ios84 TEST=e2e/uicatalog
   - DEVICE=ios84 TEST=e2e/safari/*.js


### PR DESCRIPTION
After the logging tests were moved travis began to fail.