### PR TITLE
executeAsync fix + CI

### DIFF
--- a/lib/commands/web.js
+++ b/lib/commands/web.js
@@ -308,12 +308,11 @@ helpers.executeAtom = async function (atom, args, alwaysDefaultFrame = false) {
 };
 
 helpers.executeAtomAsync = async function (atom, args, responseUrl) {
-  await this.remote.executeAtomAsync(atom, args, this.curWebFrames, responseUrl);
-
   // save the resolve and reject methods of the promise to be waited for
   let promise = new B((resolve, reject) => {
     this.asyncPromise = {resolve, reject};
   });
+  await this.remote.executeAtomAsync(atom, args, this.curWebFrames, responseUrl);
   return await this.waitForAtom(promise);
 };
 

--- a/test/e2e/safari/webview/execute-async-specs.js
+++ b/test/e2e/safari/webview/execute-async-specs.js
@@ -3,8 +3,8 @@ import desired from './desired';
 import setup from '../../setup-base';
 import { loadWebView } from '../../helpers/webview';
 
-describe('safari - webview - executeAsync @skip-ios6 @skip-ci', function() {
-  const driver = setup(this, desired, {'no-reset': true}, false, true).driver;
+describe('safari - webview - executeAsync @skip-ios6', function() {
+  const driver = setup(this, desired, {'no-reset': true}).driver;
   beforeEach(async () => await loadWebView(desired, driver));
 
   it('should bubble up javascript errors', async () => {
@@ -12,7 +12,7 @@ describe('safari - webview - executeAsync @skip-ios6 @skip-ci', function() {
   });
 
   it('should execute async javascript', async () => {
-    await driver.asyncScriptTimeout(100000);
+    await driver.asyncScriptTimeout(10000);
     (await driver.executeAsync(`arguments[arguments.length - 1](123);`)).should.be.equal(123);
   });
 

--- a/test/e2e/safari/webview/execute-async-specs.js
+++ b/test/e2e/safari/webview/execute-async-specs.js
@@ -4,7 +4,7 @@ import setup from '../../setup-base';
 import { loadWebView } from '../../helpers/webview';
 
 describe('safari - webview - executeAsync @skip-ios6', function() {
-  const driver = setup(this, desired, {'no-reset': true}).driver;
+  const driver = setup(this, desired, {'no-reset': true}, false, true).driver;
   beforeEach(async () => await loadWebView(desired, driver));
 
   it('should bubble up javascript errors', async () => {


### PR DESCRIPTION
- Fixed `executeAsync` race condition (sometimes driver attempts to resolve promise before it's created).
- Including `executeAsync` in CI