### PR TITLE
Fix handling of servers

### DIFF
--- a/test/e2e/safari/webview/execute-async-specs.js
+++ b/test/e2e/safari/webview/execute-async-specs.js
@@ -4,7 +4,7 @@ import setup from '../../setup-base';
 import { loadWebView } from '../../helpers/webview';
 
 describe('safari - webview - executeAsync @skip-ios6 @skip-ci', function() {
-  const driver = setup(this, desired, {'no-reset': true}).driver;
+  const driver = setup(this, desired, {'no-reset': true}, false, true).driver;
   beforeEach(async () => await loadWebView(desired, driver));
 
   it('should bubble up javascript errors', async () => {


### PR DESCRIPTION
We were using a single server, attached to a session. This made it so subsequent sessions could not use the server, since the `IosDriver` object was wrong. This manifest itself in 404 errors while trying to do async executes.

This starts a new server with each session. Once this is in and the build is good, we can look into handling the server in a different way (most of our calls to the server are context-less, involving only getting static pages. It is only the execute async ones that call back to the object. Perhaps we can have a single generic server that can be replaced if necessary).

@scottdixon this ought to fix the `executeAsync` woes.