### PR TITLE
Don't skip safari tests in CI

### DIFF
--- a/test/e2e/safari/webview/frames-specs.js
+++ b/test/e2e/safari/webview/frames-specs.js
@@ -7,8 +7,8 @@ import env from '../../helpers/env';
 const GET_ELEM_SYNC = `return document.getElementsByTagName('h1')[0].innerHTML;`;
 const GET_ELEM_ASYNC = `arguments[arguments.length - 1](document.getElementsByTagName('h1')[0].innerHTML);`;
 
-describe('safari - webview - frames @skip-ios6 @skip-ci', function() {
-  const driver = setup(this, desired, {'no-reset': true}).driver;
+describe('safari - webview - frames @skip-ios6', function() {
+  const driver = setup(this, desired, {'no-reset': true}, false, true).driver;
 
   beforeEach(async () => await loadWebView(
     desired,

--- a/test/e2e/safari/webview/iframes-specs.js
+++ b/test/e2e/safari/webview/iframes-specs.js
@@ -4,7 +4,7 @@ import { loadWebView } from '../../helpers/webview';
 import env from '../../helpers/env';
 
 
-describe('safari - webview - iframes @skip-ios6 @skip-ci', function() {
+describe('safari - webview - iframes @skip-ios6', function() {
   const driver = setup(this, desired, {'no-reset': true}).driver;
 
   beforeEach(async () => await loadWebView(

--- a/test/e2e/safari/webview/implicit-wait-specs.js
+++ b/test/e2e/safari/webview/implicit-wait-specs.js
@@ -1,7 +1,7 @@
 import setup from '../../setup-base';
 import desired from './desired';
 
-describe('safari - webview implicit wait @skip-ios6 @skip-ci', function() {
+describe('safari - webview implicit wait @skip-ios6', function() {
   const driver = setup(this, desired, {'no-reset': true}).driver;
 
   it('should set the implicit wait for finding web elements', async () => {

--- a/test/e2e/safari/webview/touch-specs.js
+++ b/test/e2e/safari/webview/touch-specs.js
@@ -3,7 +3,7 @@ import desired from './desired';
 import setup from '../../setup-base';
 import { loadWebView } from '../../helpers/webview';
 
-describe("safari - webview - touch actions @skip-ios6 @skip-ci", function () {
+describe("safari - webview - touch actions @skip-ios6", function () {
   const driver = setup(this, Object.assign({ 'noReset': true }, desired)).driver;
   beforeEach(async () => await loadWebView(desired, driver));
 

--- a/test/e2e/safari/webview/window-title-specs.js
+++ b/test/e2e/safari/webview/window-title-specs.js
@@ -3,7 +3,7 @@ import desired from './desired';
 import setup from '../../setup-base';
 import { loadWebView } from '../../helpers/webview';
 
-describe("safari - webview - window title @skip-ios6 @skip-ci", function () {
+describe("safari - webview - window title @skip-ios6", function () {
   const driver = setup(this, desired, {'no-reset': true}).driver;
   beforeEach(async () => await loadWebView(desired, driver));
 


### PR DESCRIPTION
A bunch of Safari tests were skipped because the tests were timing out. That doesn't happen anymore. So don't do it.