### PR TITLE
Remove extract app name functionality

### DIFF
--- a/lib/driver.js
+++ b/lib/driver.js
@@ -242,7 +242,6 @@ class IosDriver extends BaseDriver {
     await utils.parseLocalizableStrings(this.opts);
 
     await utils.setBundleIdFromApp(this.opts);
-    await utils.setAppDisplayNameFromApp(this.opts);
 
     await this.createInstruments();
 
@@ -276,7 +275,6 @@ class IosDriver extends BaseDriver {
     await utils.removeInstrumentsSocket(this.sock);
     await utils.parseLocalizableStrings(this.opts);
     await utils.setBundleIdFromApp(this.opts);
-    await utils.setAppDisplayNameFromApp(this.opts);
     await this.createInstruments();
     await this.runRealDeviceReset();
     await this.startLogCapture();

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,6 +1,6 @@
 import { fs, plist } from 'appium-support';
 import xcode from 'appium-xcode';
-import { extractBundleId, extractAppDisplayName } from 'ios-app-utils';
+import { extractBundleId } from 'ios-app-utils';
 import logger from './logger';
 import path from 'path';
 import _ from 'lodash';
@@ -194,22 +194,6 @@ async function setBundleIdFromApp (caps) {
   }
 }
 
-async function setAppDisplayNameFromApp (caps) {
-  // This method will try to extract the application's name from the app
-  if (!caps.appName) {
-    if (caps.safari) {
-      return 'Safari';
-    }
-    try {
-      caps.appName = await extractAppDisplayName(caps.app);
-      logger.info(`Extracted app name: ${caps.appName} from app '${caps.app}'`);
-    } catch (err) {
-      logger.error(`Could not set the appName from app '${caps.app}'`);
-      throw err;
-    }
-  }
-}
-
 function shouldPrelaunchSimulator (caps, iosSdkVersion) {
   let shouldPrelaunch = false;
 
@@ -242,5 +226,5 @@ function unwrapEl (el) {
 
 export default { rootDir, removeInstrumentsSocket, getAndCheckXcodeVersion, prepareIosOpts,
   appIsPackageOrBundle, getAndCheckIosSdkVersion,  detectUdid, parseLocalizableStrings,
-  setBundleIdFromApp, setAppDisplayNameFromApp, shouldPrelaunchSimulator, setDeviceTypeInInfoPlist,
+  setBundleIdFromApp, shouldPrelaunchSimulator, setDeviceTypeInInfoPlist,
   getSimForDeviceString, unwrapEl };


### PR DESCRIPTION
This was added in order to use the AppleScript background functionality. Since we no longer use that, we don't need this. Plus, it causes problems if there is no `app` capability set (https://github.com/appium/appium/issues/6051)