### PR TITLE
Restart simulator after we modify plist files

### DIFF
--- a/lib/driver.js
+++ b/lib/driver.js
@@ -586,6 +586,9 @@ class IosDriver extends BaseDriver {
       logger.error("Error setting safari preferences, prefs will not work");
       logger.error(e);
     }
+
+    logger.debug("Updated plist files, rebooting the simulator if it's already open");
+    await this.endSimulator();
   }
 
   async setLocServicesPrefs () {


### PR DESCRIPTION
`locationServicesAuthorize` was failing iOS tests. Forcing a restart after we modify plists resolved the issue.

It would always work the first time because plist files are modified before boot. Subsequent modifications wouldn't take effect.

Just ran all e2e-tests with success.

@imurchie - is this a sensible place for the restart? 