### PR TITLE
Remove skip-ios6 flag on tests

### DIFF
--- a/test/e2e/safari/basics-specs.js
+++ b/test/e2e/safari/basics-specs.js
@@ -1,7 +1,7 @@
 import setup from "../setup-base";
 import env from '../helpers/env';
 
-describe('safari - basics @skip-ios6 @skip-real-device', function() {
+describe('safari - basics @skip-real-device', function() {
   if (!(env.IOS8 || env.IOS9) && env.IOS80) {
     return describe('default init', function() {
       const driver = setup(this, { browserName: 'safari' }).driver;

--- a/test/e2e/safari/context-specs.js
+++ b/test/e2e/safari/context-specs.js
@@ -2,7 +2,7 @@ import setup from "../setup-base";
 import env from '../helpers/env';
 import B from 'bluebird';
 
-describe(`safari - context - (${env.DEVICE}) @skip-ios6`, function() {
+describe(`safari - context - (${env.DEVICE})`, function() {
   const driver = setup(this, {
     browserName: 'safari',
     nativeWebTap: true

--- a/test/e2e/safari/page-load-timeout-specs.js
+++ b/test/e2e/safari/page-load-timeout-specs.js
@@ -1,7 +1,7 @@
 import setup from "../setup-base";
 import env from '../helpers/env';
 
-describe('safari - page load timeout @skip-ios6', function() {
+describe('safari - page load timeout', function() {
   if (!env.IOS81) {
     return;
   }

--- a/test/e2e/safari/screenshot-specs.js
+++ b/test/e2e/safari/screenshot-specs.js
@@ -1,7 +1,7 @@
 import setup from "../setup-base";
 import B from 'bluebird';
 
-describe('safari - screenshots @skip-ios6', function() {
+describe('safari - screenshots', function() {
   describe('default' ,function() {
     const driver = setup(this, { browserName: 'safari' }).driver;
 

--- a/test/e2e/safari/webview/alerts-specs.js
+++ b/test/e2e/safari/webview/alerts-specs.js
@@ -2,7 +2,7 @@ import desired from './desired';
 import setup from '../../setup-base';
 import { loadWebView } from '../../helpers/webview';
 
-describe('safari - webview - alerts @skip-ios6 @skip-real-device', function() {
+describe('safari - webview - alerts @skip-real-device', function() {
   const driver = setup(this, desired, {'no-reset': true}).driver;
   beforeEach(async () => await loadWebView(desired, driver));
 

--- a/test/e2e/safari/webview/basic-specs.js
+++ b/test/e2e/safari/webview/basic-specs.js
@@ -4,7 +4,7 @@ import setup from '../../setup-base';
 import { loadWebView, spinTitle, spinWait } from '../../helpers/webview';
 
 
-describe('safari - webview - basics @skip-ios6', function() {
+describe('safari - webview - basics', function() {
   const driver = setup(this, desired, {'no-reset': true}).driver;
   beforeEach(async () => await loadWebView(desired, driver));
 

--- a/test/e2e/safari/webview/cookies-specs.js
+++ b/test/e2e/safari/webview/cookies-specs.js
@@ -3,7 +3,7 @@ import setup from '../../setup-base';
 import { loadWebView } from '../../helpers/webview';
 import env from '../../helpers/env';
 
-describe('safari - webview - cookies @skip-ios6', function() {
+describe('safari - webview - cookies', function() {
   const driver = setup(this, desired, {'no-reset': true}).driver;
 
   describe('within iframe webview', function() {

--- a/test/e2e/safari/webview/execute-async-specs.js
+++ b/test/e2e/safari/webview/execute-async-specs.js
@@ -3,7 +3,7 @@ import desired from './desired';
 import setup from '../../setup-base';
 import { loadWebView } from '../../helpers/webview';
 
-describe('safari - webview - executeAsync @skip-ios6', function() {
+describe('safari - webview - executeAsync', function() {
   const driver = setup(this, desired, {'no-reset': true}, false, true).driver;
   beforeEach(async () => await loadWebView(desired, driver));
 

--- a/test/e2e/safari/webview/execute-specs.js
+++ b/test/e2e/safari/webview/execute-specs.js
@@ -8,7 +8,7 @@ const GET_RIGHT_INNERHTML = `return document.body.innerHTML.indexOf('I am some p
 const GET_WRONG_INNERHTML = `return document.body.innerHTML.indexOf('I am not some page content') > 0`;
 const GET_ELEM_BY_TAGNAME = `return document.getElementsByTagName('a');`;
 
-describe('safari - webview - execute @skip-ios6', function() {
+describe('safari - webview - execute', function() {
   const driver = setup(this, desired, {'no-reset': true}).driver;
   before(async () => await loadWebView(desired, driver));
 

--- a/test/e2e/safari/webview/frames-specs.js
+++ b/test/e2e/safari/webview/frames-specs.js
@@ -7,7 +7,7 @@ import env from '../../helpers/env';
 const GET_ELEM_SYNC = `return document.getElementsByTagName('h1')[0].innerHTML;`;
 const GET_ELEM_ASYNC = `arguments[arguments.length - 1](document.getElementsByTagName('h1')[0].innerHTML);`;
 
-describe('safari - webview - frames @skip-ios6', function() {
+describe('safari - webview - frames', function() {
   const driver = setup(this, desired, {'no-reset': true}, false, true).driver;
 
   beforeEach(async () => await loadWebView(

--- a/test/e2e/safari/webview/iframes-specs.js
+++ b/test/e2e/safari/webview/iframes-specs.js
@@ -4,7 +4,7 @@ import { loadWebView } from '../../helpers/webview';
 import env from '../../helpers/env';
 
 
-describe('safari - webview - iframes @skip-ios6', function() {
+describe('safari - webview - iframes', function() {
   const driver = setup(this, desired, {'no-reset': true}).driver;
 
   beforeEach(async () => await loadWebView(

--- a/test/e2e/safari/webview/implicit-wait-specs.js
+++ b/test/e2e/safari/webview/implicit-wait-specs.js
@@ -1,7 +1,7 @@
 import setup from '../../setup-base';
 import desired from './desired';
 
-describe('safari - webview implicit wait @skip-ios6', function() {
+describe('safari - webview implicit wait', function() {
   const driver = setup(this, desired, {'no-reset': true}).driver;
 
   it('should set the implicit wait for finding web elements', async () => {

--- a/test/e2e/safari/webview/special-caps-specs.js
+++ b/test/e2e/safari/webview/special-caps-specs.js
@@ -3,7 +3,7 @@ import setup from '../../setup-base';
 import env from '../../helpers/env';
 import { loadWebView, spinWait } from '../../helpers/webview';
 
-describe('safari - webview - special capabilities @skip-ios6', function() {
+describe('safari - webview - special capabilities', function() {
   let specialCaps = Object.assign({}, desired);
   specialCaps.safariIgnoreFraudWarning = true;
 

--- a/test/e2e/safari/webview/touch-specs.js
+++ b/test/e2e/safari/webview/touch-specs.js
@@ -3,7 +3,7 @@ import desired from './desired';
 import setup from '../../setup-base';
 import { loadWebView } from '../../helpers/webview';
 
-describe("safari - webview - touch actions @skip-ios6", function () {
+describe("safari - webview - touch actions", function () {
   const driver = setup(this, Object.assign({ 'noReset': true }, desired)).driver;
   beforeEach(async () => await loadWebView(desired, driver));
 

--- a/test/e2e/safari/webview/window-title-specs.js
+++ b/test/e2e/safari/webview/window-title-specs.js
@@ -3,7 +3,7 @@ import desired from './desired';
 import setup from '../../setup-base';
 import { loadWebView } from '../../helpers/webview';
 
-describe("safari - webview - window title @skip-ios6", function () {
+describe("safari - webview - window title", function () {
   const driver = setup(this, desired, {'no-reset': true}).driver;
   beforeEach(async () => await loadWebView(desired, driver));
 

--- a/test/e2e/safari/windows-frame-specs.js
+++ b/test/e2e/safari/windows-frame-specs.js
@@ -4,7 +4,7 @@ import env from '../helpers/env';
 import { loadWebView, spinTitle } from "../helpers/webview";
 import B from 'bluebird';
 
-describe(`safari - windows and frames (${env.DEVICE}) @skip-ios6`, function() {
+describe(`safari - windows and frames (${env.DEVICE})`, function() {
   const driver = setup(this, {
     browserName: 'safari',
     nativeWebTap: true,
@@ -52,7 +52,7 @@ describe(`safari - windows and frames (${env.DEVICE}) @skip-ios6`, function() {
   });
 });
 
-describe(`safari - windows and frames (${env.DEVICE}) @skip-ios6 - without safariAllowPopups`, function() {
+describe(`safari - windows and frames (${env.DEVICE}) - without safariAllowPopups`, function() {
   const driver = setup(this, {
     browserName: 'safari',
     safariAllowPopups: false

--- a/test/e2e/testapp/basics/calc-app-2-specs.js
+++ b/test/e2e/testapp/basics/calc-app-2-specs.js
@@ -44,7 +44,7 @@ describe('testapp - basics - calc app 2', function () {
 
   // TODO: Fails on sauce, investigate
   // TODO: Fails with 8.4 or Appium 1.5, investigate cause
-  it.skip('should be able to get syslog logs @skip-ios6 @skip-ios8 @skip-ci', async () => {
+  it.skip('should be able to get syslog logs @skip-ios8 @skip-ci', async () => {
     await driver.implicitWait(4000);
     await B.resolve(driver.findElement('name', 'SumLabelz'))
       .catch(throwMatchableError)

--- a/test/e2e/testapp/device-specs.js
+++ b/test/e2e/testapp/device-specs.js
@@ -10,7 +10,7 @@ import '../helpers/setup_testlibs';
 describe('testapp - device', function () {
   this.timeout(env.MOCHA_INIT_TIMEOUT);
 
-  describe('invalid deviceName @skip-ios6 @skip-real-device', function () {
+  describe('invalid deviceName @skip-real-device', function () {
     it('should fail gracefully with an invalid deviceName', async () => {
       let session = new Session(_.defaults({deviceName: "iFailure 3.5-inch"},  desired),
         {'no-retry': true});
@@ -19,7 +19,7 @@ describe('testapp - device', function () {
         .should.be.rejectedWith(/Could not find a device to launch/);
     });
   });
-  describe('generic deviceName @skip-ios6', function () {
+  describe('generic deviceName', function () {
     let session;
 
     afterEach(async function () {

--- a/test/e2e/uicatalog/alerts-specs.js
+++ b/test/e2e/uicatalog/alerts-specs.js
@@ -5,7 +5,7 @@ import setup from '../setup-base';
 import desired from './desired';
 import B from 'bluebird';
 
-describe('uicatalog - alerts @skip-ios6', function () {
+describe('uicatalog - alerts', function () {
 
   let alertTag = env.IOS7 ? '@label' : '@value';
 

--- a/test/e2e/uicatalog/background-app-specs.js
+++ b/test/e2e/uicatalog/background-app-specs.js
@@ -1,7 +1,7 @@
 import setup from "../setup-base";
 import desired from './desired';
 
-describe('uicatalog - background app @skip-ios6', function () {
+describe('uicatalog - background app', function () {
   let session = setup(this, desired);
   let driver = session.driver;
 

--- a/test/e2e/uicatalog/basic-specs.js
+++ b/test/e2e/uicatalog/basic-specs.js
@@ -2,7 +2,7 @@ import env from '../helpers/env';
 import setup from "../setup-base";
 import desired from './desired';
 
-describe('uicatalog - basic @skip-ios6', () => {
+describe('uicatalog - basic', () => {
   let textTag = env.IOS7 ? '@label' : '@value';
 
   describe('api', function () {

--- a/test/e2e/uicatalog/clear-specs.js
+++ b/test/e2e/uicatalog/clear-specs.js
@@ -2,7 +2,7 @@ import setup from "../setup-base";
 import desired from './desired';
 import B from 'bluebird';
 
-describe('uicatalog - clear @skip-ios6', function () {
+describe('uicatalog - clear', function () {
 
   describe('hide keyboard', function () {
     let session = setup(this, desired);

--- a/test/e2e/uicatalog/controls-specs.js
+++ b/test/e2e/uicatalog/controls-specs.js
@@ -4,7 +4,7 @@ import { clickButton } from '../helpers/recipes';
 import B from 'bluebird';
 
 
-describe('uicatalog - controls @skip-ios6', function () {
+describe('uicatalog - controls', function () {
   let session = setup(this, desired);
   let driver = session.driver;
 

--- a/test/e2e/uicatalog/execute-specs.js
+++ b/test/e2e/uicatalog/execute-specs.js
@@ -3,7 +3,7 @@ import desired from './desired';
 import B from 'bluebird';
 import { throwMatchableError } from '../helpers/recipes';
 
-describe('uicatalog - execute @skip-ios6', function () {
+describe('uicatalog - execute', function () {
   let session = setup(this, desired);
   let driver = session.driver;
 

--- a/test/e2e/uicatalog/find-basics-specs.js
+++ b/test/e2e/uicatalog/find-basics-specs.js
@@ -4,7 +4,7 @@ import desired from './desired';
 import B from 'bluebird';
 import { clickButton, throwMatchableError } from '../helpers/recipes';
 
-describe('uicatalog - find - basics @skip-ios6', function () {
+describe('uicatalog - find - basics', function () {
   let session = setup(this, desired);
   let driver = session.driver;
 

--- a/test/e2e/uicatalog/find-by-accessibility-id-specs.js
+++ b/test/e2e/uicatalog/find-by-accessibility-id-specs.js
@@ -3,7 +3,7 @@ import setup from "../setup-base";
 import desired from './desired';
 import { clickButton } from '../helpers/recipes';
 
-describe('uicatalog - find by accessibility id @skip-ios6', function () {
+describe('uicatalog - find by accessibility id', function () {
   let session = setup(this, desired);
   let driver = session.driver;
 

--- a/test/e2e/uicatalog/find-by-ui-automation-specs.js
+++ b/test/e2e/uicatalog/find-by-ui-automation-specs.js
@@ -5,7 +5,7 @@ import B from 'bluebird';
 import { clickButton, filterDisplayed, filterVisibleUiaSelector } from '../helpers/recipes';
 //  , filterVisible = require('../../../helpers/ios-uiautomation').filterVisible;
 
-describe('uicatalog - find by ios-ui-automation @skip-ios6', function () {
+describe('uicatalog - find by ios-ui-automation', function () {
   let session = setup(this, desired);
   let driver = session.driver;
 

--- a/test/e2e/uicatalog/find-by-xpath-specs.js
+++ b/test/e2e/uicatalog/find-by-xpath-specs.js
@@ -4,7 +4,7 @@ import B from 'bluebird';
 import _ from 'lodash';
 import { throwMatchableError } from '../helpers/recipes.js';
 
-describe('uicatalog - find by xpath @skip-ios6', function () {
+describe('uicatalog - find by xpath', function () {
   let session = setup(this, desired);
   let driver = session.driver;
 

--- a/test/e2e/uicatalog/gestures/flick-specs.js
+++ b/test/e2e/uicatalog/gestures/flick-specs.js
@@ -7,7 +7,7 @@ let SLOW_DOWN_MS = 1000;
 // TODO: from the skip flick does not work in any supported ios,
 //       (the element flick actually work, just speedFlick is broken)
 //       maybe try it on real devices
-describe('uicatalog - gestures - flick @skip-ios8 @skip-ios7 @skip-ios6', function () {
+describe('uicatalog - gestures - flick @skip-ios8 @skip-ios7', function () {
   let session = setup(this, desired);
   let driver = session.driver;
 

--- a/test/e2e/uicatalog/gestures/mobile-scroll-specs.js
+++ b/test/e2e/uicatalog/gestures/mobile-scroll-specs.js
@@ -1,7 +1,7 @@
 import setup from "../../setup-base";
 import desired from '../desired';
 
-describe('uicatalog - gestures - mobile scroll @skip-ios6', function () {
+describe('uicatalog - gestures - mobile scroll', function () {
   let session = setup(this, desired);
   let driver = session.driver;
 

--- a/test/e2e/uicatalog/gestures/mobile-shake-specs.js
+++ b/test/e2e/uicatalog/gestures/mobile-shake-specs.js
@@ -1,7 +1,7 @@
 import setup from "../../setup-base";
 import desired from '../desired';
 
-describe('uicatalog - gestures - mobile shake @skip-ios6', function () {
+describe('uicatalog - gestures - mobile shake', function () {
   let session = setup(this, desired);
   let driver = session.driver;
 

--- a/test/e2e/uicatalog/load-app/load-abs-path-app-specs.js
+++ b/test/e2e/uicatalog/load-app/load-abs-path-app-specs.js
@@ -3,7 +3,7 @@ import desired from '../desired';
 import path from 'path';
 import _ from 'lodash';
 
-describe('uicatalog - load app with absolute path @skip-ios6', function () {
+describe('uicatalog - load app with absolute path', function () {
   let appPath = path.resolve(desired.app);
 
   let session = setup(this, _.defaults({'app': appPath}, desired));

--- a/test/e2e/uicatalog/load-app/load-abs-path-zipped-app-specs.js
+++ b/test/e2e/uicatalog/load-app/load-abs-path-zipped-app-specs.js
@@ -3,7 +3,7 @@ import desired from '../desired';
 import path from 'path';
 import _ from 'lodash';
 
-describe('uicatalog - load zipped app @skip-ios6', function () {
+describe('uicatalog - load zipped app', function () {
   let appZipPath = path.resolve('test/assets/UICatalog7.1.app.zip');
 
   let session = setup(this, _.defaults({'app': appZipPath}, desired));

--- a/test/e2e/uicatalog/load-app/load-rel-path-app-specs.js
+++ b/test/e2e/uicatalog/load-app/load-rel-path-app-specs.js
@@ -3,7 +3,7 @@ import desired from '../desired';
 import path from 'path';
 import _ from 'lodash';
 
-describe('uicatalog - load app with relative path @skip-ios6', function () {
+describe('uicatalog - load app with relative path', function () {
   let appPath = path.relative(process.cwd(), desired.app);
 
   let session = setup(this, _.defaults({'app': appPath}, desired));

--- a/test/e2e/uicatalog/load-app/load-rel-path-zipped-app-specs.js
+++ b/test/e2e/uicatalog/load-app/load-rel-path-zipped-app-specs.js
@@ -3,7 +3,7 @@ import desired from '../desired';
 import path from 'path';
 import _ from 'lodash';
 
-describe('uicatalog - load zipped app with relative path @skip-ios6', function () {
+describe('uicatalog - load zipped app with relative path', function () {
 
   let appZipPath = 'test/assets/UICatalog7.1.app.zip';
 

--- a/test/e2e/uicatalog/load-app/load-zipped-url-app-specs.js
+++ b/test/e2e/uicatalog/load-app/load-zipped-url-app-specs.js
@@ -3,7 +3,7 @@ import desired from '../desired';
 import _ from 'lodash';
 
 // TODO: skipping on real device because we would need a signed app
-describe('uicatalog - load zipped app via url @skip-real-device @skip-ios6', function () {
+describe('uicatalog - load zipped app via url @skip-real-device', function () {
 
   let appUrl = 'https://appium.s3.amazonaws.com/TestApp7.1.app.zip';
 

--- a/test/e2e/uicatalog/lock-device-specs.js
+++ b/test/e2e/uicatalog/lock-device-specs.js
@@ -2,7 +2,7 @@ import env from '../helpers/env';
 import setup from "../setup-base";
 import desired from './desired';
 
-describe('uicatalog - lock device @skip-ios6', function () {
+describe('uicatalog - lock device', function () {
   let session = setup(this, desired);
   let driver = session.driver;
 

--- a/test/e2e/uicatalog/move-specs.js
+++ b/test/e2e/uicatalog/move-specs.js
@@ -2,7 +2,7 @@ import env from '../helpers/env';
 import setup from "../setup-base";
 import desired from './desired';
 
-describe('uicatalog - move @skip-ios6', function () {
+describe('uicatalog - move', function () {
 
   describe('moveTo and click', function () {
     let session = setup(this, desired);

--- a/test/e2e/uicatalog/reset-specs.js
+++ b/test/e2e/uicatalog/reset-specs.js
@@ -2,7 +2,7 @@ import setup from "../setup-base";
 import desired from './desired';
 import B from 'bluebird';
 
-describe('uicatalog - reset @skip-ios6', function () {
+describe('uicatalog - reset', function () {
 
   describe('app reset', function () {
     let session = setup(this, desired);

--- a/test/e2e/uicatalog/touch-specs.js
+++ b/test/e2e/uicatalog/touch-specs.js
@@ -1,7 +1,7 @@
 import setup from "../setup-base";
 import desired from './desired';
 
-describe('uicatalog - touch @skip-ios6', function () {
+describe('uicatalog - touch', function () {
   let session = setup(this, desired);
   let driver = session.driver;
 

--- a/test/e2e/uicatalog/window-specs.js
+++ b/test/e2e/uicatalog/window-specs.js
@@ -1,7 +1,7 @@
 import setup from "../setup-base";
 import desired from './desired';
 
-describe('uicatalog - contexts @skip-ios6', function () {
+describe('uicatalog - contexts', function () {
   let session = setup(this, desired);
   let driver = session.driver;
 


### PR DESCRIPTION
We don't support iOS 6 anymore, so no need to have the flag to skip in tests.