### PR TITLE
Fix handling of locale changes

### DIFF
--- a/lib/driver.js
+++ b/lib/driver.js
@@ -485,7 +485,9 @@ class IosDriver extends BaseDriver {
 
   async endSimulator () {
     logger.debug("Killing the simulator");
-    await this.sim.shutdown();
+    if (this.sim) {
+      await this.sim.shutdown();
+    }
   }
 
   async isolateSimDevice () {
@@ -501,56 +503,35 @@ class IosDriver extends BaseDriver {
   }
 
   async setLocale () {
-    let msg;
-    let setLoc = async () => {
-      logger.debug("Setting locale information");
-      let needSimRestart = false;
-      this.localeConfig = this.localeConfig || {};
-      _(['language', 'locale', 'calendarFormat']).each(function (key) {
-        needSimRestart = needSimRestart ||
-                        (this.opts[key] &&
-                         this.opts[key] !== this.localeConfig[key]);
-      }, this);
-      this.localeConfig = {
-        language: this.opts.language,
-        locale: this.opts.locale,
-        calendarFormat: this.opts.calendarFormat
-      };
+    if (this.isRealDevice()) {
+      logger.debug("Not setting locale because we're using a real device");
+      return;
+    } else if (!this.opts.language && !this.opts.locale && !this.opts.calendarFormat) {
+      logger.debug("Not setting locale");
+      return;
+    }
 
-      try {
-        await this.sim.updateLocale(this.opts.language, this.opts.locale, this.opts.calendarFormat);
-      } catch (e) {
-        msg = `Appium was unable to set locale info: ${e}`;
-        logger.errorAndThrow(msg);
-      }
+    // we need the simulator to have its directories in place
+    if (await this.sim.isFresh()) {
+      this.launchAndQuitSimulator();
+    }
 
-      logger.debug("Locale was set");
-      if (needSimRestart) {
-        logger.debug("First time setting locale, or locale changed, killing existing Instruments and Sim procs.");
-        await instrumentsUtils.killAllInstruments();
-        await killAllSimulators();
-        await B.delay(250);
-      }
+    logger.debug("Setting locale information");
+    this.localeConfig = this.localeConfig || {};
+    this.localeConfig = {
+      language: this.opts.language || this.localeConfig.language,
+      locale: this.opts.locale || this.localeConfig.locale,
+      calendarFormat: this.opts.calendarFormat || this.localeConfig.calendarFormat
     };
 
-
-    if ((this.opts.language || this.opts.locale || this.opts.calendarFormat) && (_.isNull(this.opts.udid) || _.isUndefined(this.opts.udid))) {
-
-      if (this.opts.fullReset && this.opts.platformVersion <= 6.1) {
-        msg = "Cannot set locale information because a full-reset was requested. full-reset interferes with the language/locale caps on iOS 6.1 and older";
-        logger.error(msg);
-        throw new Error(msg);
+    try {
+      let updated = await this.sim.updateLocale(this.opts.language, this.opts.locale, this.opts.calendarFormat);
+      if (updated) {
+        logger.debug('Locale was updated. Stopping simulator.');
+        await this.endSimulator();
       }
-
-      if (await this.sim.isFresh()) {
-        this.launchAndQuitSimulator();
-      }
-
-      await setLoc();
-    } else if (this.isRealDevice()) {
-      logger.debug("Not setting locale because we're using a real device");
-    } else {
-      logger.debug("Not setting locale");
+    } catch (e) {
+      logger.errorAndThrow(`Appium was unable to set locale info: ${e}`);
     }
   }
 

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "appium-express": "^1.0.0",
     "appium-instruments": "^3.0.0",
     "appium-ios-log": "^1.0.0",
-    "appium-ios-simulator": "^1.1.6",
+    "appium-ios-simulator": "^1.3.0",
     "appium-logger": "^2.0.0",
     "appium-remote-debugger": "^1.7.0",
     "appium-support": "^2.0.7",


### PR DESCRIPTION
Changing locale didn't work on iOS 9+. It was also unnecessarily convoluted and complex.