### PR TITLE
Make sure that we lint before running tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,7 @@ before_script:
   - npm install -g gulp
   - npm install -g mocha
   - gulp transpile
+  - gulp jshint
 script:
   - if [ -n "$RECURSIVE" ]; then mocha --recursive build/test/$TEST -g @skip-ci -i; else mocha build/test/$TEST -g @skip-ci -i; fi
   - if [ -n "$FINAL_GULP" ]; then gulp $FINAL_GULP; fi

--- a/test/e2e/helpers/env.js
+++ b/test/e2e/helpers/env.js
@@ -62,6 +62,7 @@ switch (env.DEVICE) {
   case 'ios6_iphone':
   case 'ios6_ipad':
     env.CAPS.deviceName = iphoneOrIpadSimulator(env.DEVICE, "6.1");
+    break;
   case 'ios7':
   case 'ios7_iphone':
   case 'ios7_ipad':


### PR DESCRIPTION
And `gulp jshint` to our `before_script` block in Travis. Thus catching style errors as early as possible, as much as is feasible.