### PR TITLE
return correct information on create session

### DIFF
--- a/lib/driver.js
+++ b/lib/driver.js
@@ -136,7 +136,7 @@ class IosDriver extends BaseDriver {
 
     // TODO: this should be in BaseDriver.postCreateSession
     this.startNewCommandTimeout('createSession');
-    return [sessionId, this.opts];
+    return [sessionId, this.caps];
   }
 
   async stop () {


### PR DESCRIPTION
Fixes https://github.com/appium/appium/issues/5920

createSession wasn't returning the `javascriptEnabled` server capability - ruby client wouldn't execute JS.

CC @imurchie @KazuCocoa