### PR TITLE
Undo uiauto update, to see if flakiness of uicatalog goes away

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "appium-logger": "^2.1.0",
     "appium-remote-debugger": "^2.0.0",
     "appium-support": "^2.0.9",
-    "appium-uiauto": "^2.2.0",
+    "appium-uiauto": "^2.3.1",
     "appium-xcode": "^3.1.0",
     "asyncbox": "^2.2.0",
     "babel-runtime": "=5.8.24",

--- a/test/e2e/helpers/session.js
+++ b/test/e2e/helpers/session.js
@@ -54,7 +54,7 @@ class Session {
     if (env.MAX_RETRY) attempts = Math.min(env.MAX_RETRY, attempts);
     await init(attempts);
     this.initialized = true;
-    this.driver.implicitWait(env.IMPLICIT_WAIT_TIMEOUT);
+    await this.driver.implicitWait(env.IMPLICIT_WAIT_TIMEOUT);
   }
 
   async tearDown () {

--- a/test/e2e/uicatalog/find-by-xpath-specs.js
+++ b/test/e2e/uicatalog/find-by-xpath-specs.js
@@ -59,6 +59,7 @@ describe('uicatalog - find by xpath', function () {
     });
 
     it('should filter by indices', async () => {
+      await driver.implicitWait(10000);
       let el = await driver.findElement('xpath', "//UIATableCell[4]/UIAButton[1]");
       (await driver.getAttribute('name', el)).should.equal('X Button');
     });


### PR DESCRIPTION
`uiscatalog` tests have been flakey as of late. Can we do something about that?