### PR TITLE
Make context retrieval not depend on url

### DIFF
--- a/lib/commands/context.js
+++ b/lib/commands/context.js
@@ -24,7 +24,7 @@ commands.getCurrentContext = async function () {
 
 commands.getContexts = async function () {
   logger.debug('Getting list of available contexts');
-  let contexts = await this.getContextsAndViews();
+  let contexts = await this.getContextsAndViews(false);
   return contexts.map((context) => context.id);
 };
 
@@ -142,9 +142,9 @@ extensions.initAutoWebview = async function () {
   }
 };
 
-extensions.getContextsAndViews = async function () {
+extensions.getContextsAndViews = async function (useUrl = true) {
   logger.debug('Retrieving contexts and views');
-  let webviews = await this.listWebFrames();
+  let webviews = await this.listWebFrames(useUrl);
   let ctxs = [{id: NATIVE_WIN}];
   this.contexts = [NATIVE_WIN];
   for (let view of webviews) {
@@ -154,17 +154,22 @@ extensions.getContextsAndViews = async function () {
   return ctxs;
 };
 
-extensions.listWebFrames = async function () {
+extensions.listWebFrames = async function (useUrl = true) {
   if (!this.opts.bundleId) {
     logger.errorAndThrow('Cannot enter web frame without a bundle ID');
   }
 
+  /* jshint ignore:start */
+  logger.debug(`Selecting by url: ${useUrl} ${useUrl ? `(expected url: '${this.getCurrentUrl()}')` : ''}`);
+  /* jshint ignore:end */
+
+  let currentUrl = useUrl ? this.getCurrentUrl() : undefined;
   let pageArray;
   if (this.remote !== null && this.remote.appIdKey && this.opts.bundleId !== null) {
     if (this.isRealDevice()) {
       pageArray = await this.remote.pageArrayFromJson();
     } else {
-      pageArray = await this.remote.selectApp(this.getCurrentUrl(), this.opts.webviewConnectRetries);
+      pageArray = await this.remote.selectApp(currentUrl, this.opts.webviewConnectRetries);
     }
   } else {
     if (this.isRealDevice()) {
@@ -183,7 +188,7 @@ extensions.listWebFrames = async function () {
       logger.debug('Unable to connect to the remote debugger.');
       return [];
     }
-    pageArray = await this.remote.selectApp(this.getCurrentUrl(), this.opts.webviewConnectRetries);
+    pageArray = await this.remote.selectApp(currentUrl, this.opts.webviewConnectRetries);
     this.remote.on(RemoteDebugger.EVENT_PAGE_CHANGE, this.onPageChange.bind(this));
 
     let tryClosingAlert = async () => {


### PR DESCRIPTION
When we get the contexts by themselves we should not care about the url.