### PR TITLE
Change browserName for server capabilities

### DIFF
--- a/lib/driver.js
+++ b/lib/driver.js
@@ -30,7 +30,7 @@ let iDevice = function (...args) {
 let serverCapabilities = {
   webStorageEnabled: false,
   locationContextEnabled: false,
-  browserName: 'iOS',
+  browserName: '',
   platform: 'MAC',
   javascriptEnabled: true,
   databaseEnabled: false,


### PR DESCRIPTION
Rather than having an invalid `browserName` as a server capability, use `''`.

Addresses https://github.com/appium/appium/issues/6177