### PR TITLE
Fix handling of arguments to execute

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ console.log(await driver.getOrientation()); // -> 'LANDSCAPE'
 | `closeAlertBeforeTest`            |
 | `closeApp`                        |
 | `closeWindow`                     |
-| `convertElementForAtoms`          |
+| `convertElementsForAtoms`         |
 | `deleteCookie`                    |
 | `deleteCookies`                   |
 | `elementDisplayed`                |

--- a/lib/commands/execute.js
+++ b/lib/commands/execute.js
@@ -9,8 +9,8 @@ let commands = {}, helpers = {}, extensions = {};
 
 commands.execute = async function (script, args) {
   if (this.isWebContext()) {
-    let el = this.convertElementForAtoms(args);
-    return await this.executeAtom('execute_script', [script, el]);
+    args = this.convertElementsForAtoms(args);
+    return await this.executeAtom('execute_script', [script, args]);
   } else {
     if (script.match(/^mobile\:/)) {
       script = script.replace(/^mobile\:/, '').trim();
@@ -46,7 +46,7 @@ commands.executeAsync = async function (script, args, sessionId) {
   }
 
   logger.debug(`Response url for executeAsync: ${responseUrl}`);
-  args = this.convertElementForAtoms(args);
+  args = this.convertElementsForAtoms(args);
   return await this.executeAtomAsync('execute_async_script', [script, args, this.asyncWaitMs], responseUrl);
 };
 

--- a/lib/commands/web.js
+++ b/lib/commands/web.js
@@ -391,7 +391,7 @@ helpers.useAtomsElement = function (el) {
   return atomsElement;
 };
 
-helpers.convertElementForAtoms = function (args = []) {
+helpers.convertElementsForAtoms = function (args = []) {
   let newArgs = [];
   for (let arg of args) {
     if (!_.isNull(arg) && !_.isUndefined(arg.ELEMENT)) {
@@ -400,6 +400,8 @@ helpers.convertElementForAtoms = function (args = []) {
         throw new errors.UnknownError(`Error converting element ID for using in WD atoms: ${arg.ELEMENT}`);
       }
       newArgs.push(atomsElement);
+    } else {
+      newArgs.push(arg);
     }
   }
   return newArgs;

--- a/test/e2e/safari/webview/execute-specs.js
+++ b/test/e2e/safari/webview/execute-specs.js
@@ -47,4 +47,8 @@ describe('safari - webview - execute', function() {
     let res = await driver.execute(GET_ELEM_BY_TAGNAME);
     expect(res).to.have.length.above(0);
   });
+  it('should pass along non-element arguments', async () => {
+    let arg = 'non-element-argument';
+    (await driver.execute('var args = Array.prototype.slice.call(arguments, 0); return args[0];', [arg])).should.be.equal(arg);
+  });
 });


### PR DESCRIPTION
We were only converting element arguments and skipping the rest. Fix that.