### PR TITLE
Make sure we note ipa file

### DIFF
--- a/lib/driver.js
+++ b/lib/driver.js
@@ -204,6 +204,14 @@ class IosDriver extends BaseDriver {
         this.opts.bundleId = this.opts.app;
       }
 
+      // if we have an ipa file, set it in opts
+      if (this.opts.app) {
+        let ext = this.opts.app.substring(this.opts.app.length - 4).toLowerCase();
+        if (ext === 'ipa') {
+          this.opts.ipa = this.opts.app;
+        }
+      }
+
       if (this.opts.app && this.opts.app.toLowerCase() === "settings") {
         if (parseFloat(this.opts.platformVersion) >= 8) {
           logger.debug("We are on iOS8+ so not copying preferences app");


### PR DESCRIPTION
We do some logic (like `fullReset`) based on whether we have an `ipa` file or not. But we were not keeping track of that.

Addresses https://github.com/appium/appium/issues/6206