### PR TITLE
Fix compatibility with appium-instruments 3.6.4

### DIFF
--- a/lib/driver.js
+++ b/lib/driver.js
@@ -877,8 +877,7 @@ class IosDriver extends BaseDriver {
     }
 
     logger.debug("Checking whether instruments supports our device string");
-    let availDevices = await retry(3, instrumentsUtils.getAvailableDevices, this.xcodeVersion,
-      this.iosSdkVersion, this.opts);
+    let availDevices = await retry(3, instrumentsUtils.getAvailableDevices);
     let dString = await this.adjustedDeviceName();
     let noDevicesError = function () {
       let msg = `Could not find a device to launch. You requested ` +

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "appium-base-driver": "^1.4.1",
     "appium-cookies": "^1.1.0",
     "appium-express": "^1.2.2",
-    "appium-instruments": "^3.6.3",
+    "appium-instruments": "^3.6.4",
     "appium-ios-log": "^1.2.0",
     "appium-ios-simulator": "^1.5.3",
     "appium-logger": "^2.1.0",


### PR DESCRIPTION
This fix removes parameters to a call which previously didn't take parameters but now does. The parameters passed by the driver cause the method call to fail.

Recent versions of `appium-instruments` have taken no parameters to `getAvailableDevices` so passing the `xcodeVersion` etc had no effect. With the latest version [`3.6.4`](https://github.com/appium/appium-instruments/compare/2fb29998df161fcb6f19ddbf27c9844acb747094...23d689b) the first parameter is a timeout value.

This results in the driver not working as it passes a `timeout` value of `7.2.1` on Xcode 7.2.1 causing an error.
