### PR TITLE
Don't throw an error if logs are already there

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,9 @@ env:
 language:
   - objective-c
 osx_image: xcode6.4
+cache:
+  directories
+    - node_modules
 before_install:
   # TavisCI's OSX environment gives us node 0.10.32
   # Use NVM to update it to 0.12

--- a/lib/commands/general.js
+++ b/lib/commands/general.js
@@ -85,7 +85,7 @@ commands.closeApp = async function () {
     await this.stop();
     log.info(`Successfully closed the [${this.opts.app}] app.`);
   } catch (err) {
-    log.warn(`Something went wrong whilst closing the [${this.opts.app}] app.`);
+    log.warn(`Something went wrong while closing the [${this.opts.app}] app.`);
     throw err;
   }
 };
@@ -95,7 +95,7 @@ commands.launchApp = async function () {
     await this.start();
     log.info(`Successfully launched the [${this.opts.app}] app.`);
   } catch (err) {
-    log.warn(`Something went wrong whilst launching the [${this.opts.app}] app.`);
+    log.warn(`Something went wrong while launching the [${this.opts.app}] app.`);
     throw err;
   }
 };

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -661,7 +661,8 @@ class IosDriver extends BaseDriver {
 
   async startLogCapture () {
     if (!_.isEmpty(this.logs)) {
-      throw new Error("Trying to start iOS log capture but it's already started!");
+      logger.warn("Trying to start iOS log capture but it's already started!");
+      return;
     }
     this.logs.crashlog = new IOSCrashLog();
     this.logs.syslog = new IOSLog({

--- a/test/e2e/uicatalog/controls-specs.js
+++ b/test/e2e/uicatalog/controls-specs.js
@@ -44,7 +44,7 @@ describe('uicatalog - controls', function () {
 
     await driver.setValue(0.8, slider);
     // give a moment for the change to register
-    await B.delay(500);
+    await B.delay(5000);
 
     value = await driver.getAttribute("value", slider);
     value = parseInt(value.replace('%', ''), 10);

--- a/test/e2e/uicatalog/reset-specs.js
+++ b/test/e2e/uicatalog/reset-specs.js
@@ -29,5 +29,13 @@ describe('uicatalog - reset', function () {
       let els = await driver.findElements('class name', 'UIATableView');
       els.should.have.length(1);
     });
+
+    it.only('should launch app even if it is already launched', async () => {
+      rawDriver.ready.should.be.ok;
+      await driver.launchApp();
+      rawDriver.ready.should.be.ok;
+      let els = await driver.findElements('class name', 'UIATableView');
+      els.should.have.length(1);
+    });
   });
 });


### PR DESCRIPTION
There is no need to completely die. This situation has come up when a user calls `launchApp` without closing the app first. This should be fine but currently fails because logs are already there.

Addresses https://github.com/appium/appium/issues/6346