### PR TITLE
Make sure getWindowHandles returns strings

### DIFF
--- a/lib/commands/context.js
+++ b/lib/commands/context.js
@@ -25,7 +25,7 @@ commands.getCurrentContext = async function () {
 commands.getContexts = async function () {
   logger.debug('Getting list of available contexts');
   let contexts = await this.getContextsAndViews(false);
-  return contexts.map((context) => context.id);
+  return contexts.map((context) => context.id.toString());
 };
 
 commands.setContext = async function (name, callback, skipReadyCheck) {
@@ -86,7 +86,7 @@ commands.getWindowHandle = async function () {
   if (!this.isWebContext()) {
     throw new errors.NotImplementedError();
   }
-  return this.curContext;
+  return this.curContext.toString();
 };
 
 commands.getWindowHandles = async function () {
@@ -103,7 +103,7 @@ commands.getWindowHandles = async function () {
   if (!this.contexts) {
     this.contexts = idArray;
   }
-  return idArray;
+  return _.map(idArray, id => id.toString());
 };
 
 commands.setWindow = async function (name, skipReadyCheck) {


### PR DESCRIPTION
The spec says it needs to be an array of strings. 

Resolves https://github.com/appium/appium/issues/6396