### PR TITLE
Remove safari-only restriction for browserName capability

### DIFF
--- a/lib/desired-caps.js
+++ b/lib/desired-caps.js
@@ -7,8 +7,7 @@ const desiredCapConstraints = {
     inclusionCaseInsensitive: ['iOS']
   },
   browserName: {
-    isString: true,
-    inclusion: ['Safari', 'safari']
+    isString: true
   },
   app: {
     isString: true


### PR DESCRIPTION
Fixes appium/appium/issues/6412

#5 added desired capabilities restraints, which restrict the allowed `browserName` for iOS to be only one of `['Safari', 'safari']`. However, the Appium docs have long recommended using `browserName` as a way to specify the type of simulator/device being used, as shown in the [example Grid node configuration](http://appium.io/slate/en/master/?ruby#grid-node-configuration-example-json-file):
```
          "browserName": "<e.g._iPhone5_or_iPad4>",
```

This means existing Selenium Grid -> Appium node configurations using `browserName` to specify node sessions in this way are effectively incompatible with Appium v1.5 since you now get the error:
```
[BaseDriver] SessionNotCreatedError: A new session could not be created. Details: The desiredCapabilities object was not valid for the following reason(s): browserName iPhone 6s is not included in the list.
```

Removing the specific `[Ss]afari` `browserName` restriction allows the Selenium grid to find the node properly, in which case the desired caps are passed along to the Appium server and `browserName` is ignored (since the `app` capability takes precedence). The restrictions may overall be a good thing and catch misconfigurations, but I think they should be backwards compatible with existing implementations. There is not really an alternative for Selenium Grid to be able to match nodes that I know of aside from using the catch-all `applicationName` capability, which is not well documented and requires modifying existing configurations.

I've tested this with Appium v1.5.1 and Selenium Grid 2.52.0. Will follow-up for `appium-android-driver` if this is accepted.