### PR TITLE
Open new window if Safari URL bar is not found

### DIFF
--- a/lib/commands/context.js
+++ b/lib/commands/context.js
@@ -347,32 +347,52 @@ extensions.navToInitialWebview = async function () {
 extensions.typeAndNavToUrl = async function () {
   this.setCurrentUrl(this.caps.safariInitialUrl || `http://127.0.0.1:${this.opts.port}/welcome`);
 
-  let oldImpWait = this.implicitWaitMs;
-  this.implicitWaitMs = 7000;
+  let tries = 0;
+  const MAX_TRIES = 2;
+  let navigate = async () => {
+    let oldImpWait = this.implicitWaitMs;
+    this.implicitWaitMs = 7000;
 
-  // find the url bar, and tap on it. retry to make sure we don't try
-  // too soon while the view is still loading
-  let el = await retryInterval(3, 1000, async () => {
-    return await this.findElement('accessibility id', 'URL');
-  });
-  this.implicitWaitMs = oldImpWait;
-  await this.nativeTap(el.ELEMENT);
+    // find the url bar, and tap on it. retry to make sure we don't try
+    // too soon while the view is still loading
+    let el = await retryInterval(3, 1000, async () => {
+      return await this.findElement('accessibility id', 'URL');
+    });
+    this.implicitWaitMs = oldImpWait;
 
-  // get the last address element and set the url
-  // this is flakey on certain systems so we retry until we get something
-  let elId = await retryInterval(5, 1000, async () => {
-    let el = _.last(await this.findElements('class name', 'UIATextField'));
-    return el.ELEMENT;
-  });
-  await this.setValueImmediate(this.getCurrentUrl(), elId);
+    try {
+      await this.nativeTap(el.ELEMENT);
+    } catch (err) {
+      if (_.includes(err.message, 'could not be tapped')) {
+        if (tries++ >= MAX_TRIES) throw err;
 
-  // make it happen
-  el = await this.findElement('accessibility id', 'Go');
-  await this.nativeTap(el.ELEMENT);
-  await this.navToViewWithTitle(/.*/i);
+        // generally this means that Safari is in page viewing mode
+        // so try to open a new page and then redo the navigation
+        let newPageButton = await this.findElement('xpath', "//UIAButton[contains(@name,'New page')]");
+        await this.nativeTap(newPageButton.ELEMENT);
+        return await navigate();
+      } else {
+        throw err;
+      }
+    }
 
-  // wait for page to finish loading.
-  await this.remote.pageUnload();
+    // get the last address element and set the url
+    // this is flakey on certain systems so we retry until we get something
+    let elId = await retryInterval(5, 1000, async () => {
+      let el = _.last(await this.findElements('class name', 'UIATextField'));
+      return el.ELEMENT;
+    });
+    await this.setValueImmediate(this.getCurrentUrl(), elId);
+
+    // make it happen
+    el = await this.findElement('accessibility id', 'Go');
+    await this.nativeTap(el.ELEMENT);
+    await this.navToViewWithTitle(/.*/i);
+
+    // wait for page to finish loading.
+    await this.remote.pageUnload();
+  };
+  await navigate();
 };
 
 extensions.navToViewThroughFavorites = async function () {


### PR DESCRIPTION
When Safari is in the state where all the pages are visible, we cannot tap the URL bar, and so we cannot initialize a Safari session. In this case, find the "New page" button and tap on it to get into a useable Safari state.