### PR TITLE
Add logging if safari test is started with no keyboard

### DIFF
--- a/lib/commands/context.js
+++ b/lib/commands/context.js
@@ -397,8 +397,16 @@ extensions.typeAndNavToUrl = async function () {
     await this.setValueImmediate(this.getCurrentUrl(), elId);
 
     // make it happen
-    el = await this.findElement('accessibility id', 'Go');
-    await this.nativeTap(el.ELEMENT);
+    try {
+      el = await this.findElement('accessibility id', 'Go');
+      await this.nativeTap(el.ELEMENT);
+    } catch (err) {
+      if (_.includes(err.message, 'could not be tapped')) {
+        logger.error('Unable to submit URL because \'Go\' button could not be tapped. ' +
+                     'Please make sure your keyboard is toggled on.');
+      }
+      throw err;
+    }
     await this.navToViewWithTitle(/.*/i);
 
     // wait for page to finish loading.


### PR DESCRIPTION
In the case that the user does not have the keyboard toggled on, Safari will not be able to load. Add logging for this case.