### PR TITLE
Allow no webkit proxy on connect

### DIFF
--- a/lib/commands/context.js
+++ b/lib/commands/context.js
@@ -173,8 +173,20 @@ extensions.listWebFrames = async function (useUrl = true) {
     pageArray = await this.remote.selectApp(currentUrl, this.opts.webviewConnectRetries);
   } else if (this.isRealDevice()) {
     // real device, and not connected
-    this.remote = new WebKitRemoteDebugger({port: this.opts.webkitDebugProxyPort});
-    pageArray = await this.remote.pageArrayFromJson();
+    try {
+      this.remote = new WebKitRemoteDebugger({port: this.opts.webkitDebugProxyPort});
+      pageArray = await this.remote.pageArrayFromJson();
+    } catch (err) {
+      // it is reasonable to expect that this might be called when there is no
+      // webkit remote debugger to connect to
+      if (!_.includes(err.message, 'connect ECONNREFUSED')) throw err;
+
+      logger.warn('Attempted to get a list of webview contexts but could not connect to ' +
+                  'ios-webkit-debug-proxy. If you expect to find webviews, please ensure ' +
+                  'that the proxy is running and accessible');
+      this.remote = null;
+      pageArray = [];
+    }
   } else {
     // simulator, and not connected
     this.remote = new RemoteDebugger({


### PR DESCRIPTION
On real device tests, if you call `getContexts` and don't ever expect there to be one (in a native app, say), and therefore are not running the ios-webkit-debug-proxy, it will error out with a connection refused error. This is not what we want.