### PR TITLE
Make sure scroll doesn't throw an error when it hits the end of a view

### DIFF
--- a/lib/commands/gesture.js
+++ b/lib/commands/gesture.js
@@ -2,6 +2,8 @@ import { errors } from 'appium-base-driver';
 import _ from 'lodash';
 import B from 'bluebird';
 import { unwrapEl } from '../utils';
+import logger from '../logger';
+
 
 let commands = {}, helpers = {}, extensions = {};
 const FLICK_MS = 3000;
@@ -311,7 +313,7 @@ helpers.mobileScroll = async function (opts={}) {
     // not implemented yet in web
     throw new errors.NotYetImplementedError();
   } else {
-    direction = direction.charAt(0).toUpperCase() + direction.slice(1);
+    direction = _.capitalize(direction);
     let command;
     if (_.isNull(el) || _.isUndefined(el)) {
       // By default, scroll the first scrollview.
@@ -320,7 +322,14 @@ helpers.mobileScroll = async function (opts={}) {
       // if element is defined, call scrollLeft, scrollRight, scrollUp, and scrollDown on the element.
       command = `au.getElement('${el}').scroll${direction}()`;
     }
-    await this.uiAutoClient.sendCommand(command);
+    try {
+      await this.uiAutoClient.sendCommand(command);
+    } catch (err) {
+      if (!_.includes(err.message, 'kAXErrorFailure')) throw err;
+
+      logger.warn('Received kAXErrorFailure, generally indicating an attempt ' +
+                  'to scroll past the end of the view. Continuing.');
+    }
   }
 };
 

--- a/test/e2e/uicatalog/gesture-specs.js
+++ b/test/e2e/uicatalog/gesture-specs.js
@@ -18,9 +18,8 @@ describe('uicatalog - touch', function () {
       try {
         await driver.back();
       } catch (ign) {}
-      try {
-        await driver.execute("mobile: scroll", {direction: 'down'});
-      } catch (ign) {}
+
+      await driver.execute("mobile: scroll", {direction: 'down'});
     });
 
     afterEach(async () => {
@@ -89,10 +88,9 @@ describe('uicatalog - touch', function () {
       try {
         await driver.back();
       } catch (ign) {}
-      try {
-        // we want to begin at the top, so try to scroll up there
-        await driver.execute("mobile: scroll", {direction: 'up'});
-      } catch (ign) {}
+
+      // we want to begin at the top, so try to scroll up there
+      await driver.execute("mobile: scroll", {direction: 'up'});
     });
 
     it('should scroll down and up', async () => {
@@ -125,6 +123,14 @@ describe('uicatalog - touch', function () {
       loc3.x.should.equal(loc2.x);
       loc3.y.should.not.equal(loc2.y);
     });
+
+    it('should be able to be called multiple times', async () => {
+      await driver.execute("mobile: scroll", {direction: 'down'});
+      await driver.execute("mobile: scroll", {direction: 'down'});
+      await driver.execute("mobile: scroll", {direction: 'down'});
+      await driver.execute("mobile: scroll", {direction: 'down'});
+      await driver.execute("mobile: scroll", {direction: 'down'});
+    });
   });
 
   describe('mobile shake', function () {
@@ -134,6 +140,16 @@ describe('uicatalog - touch', function () {
   });
 
   describe('moveTo and click', function () {
+    before(async () => {
+      try {
+        await driver.back();
+      } catch (ign) {}
+      try {
+        // we want to begin at the top, so try to scroll up there
+        await driver.execute("mobile: scroll", {direction: 'up'});
+      } catch (ign) {}
+    });
+    
     it('should be able to click on arbitrary x-y elements', async () => {
       let axIdExt = env.IOS8 || env.IOS9 ? "" : ", AAPLButtonViewController";
       let el1 = await driver.findElement('accessibility id', `Buttons${axIdExt}`);


### PR DESCRIPTION
Otherwise oyu need to wrap every `mobile: scroll` call to catch an error when it hits the end of the view.