### PR TITLE
prevent getUrl from breaking getWindowHandles - resolves #6506

### DIFF
--- a/lib/commands/web.js
+++ b/lib/commands/web.js
@@ -78,7 +78,6 @@ commands.getUrl = async function () {
     throw new errors.NotImplementedError();
   }
   let url = await this.remote.execute('window.location.href');
-  this.setCurrentUrl(url);
   return url;
 };
 

--- a/test/e2e/safari/webview/basic-specs.js
+++ b/test/e2e/safari/webview/basic-specs.js
@@ -117,6 +117,13 @@ describe('safari - webview - basics', function() {
       (await driver.getUrl()).should.include('test/guinea-pig');
     });
 
+    it('should get updated URL without breaking window handles', async () => {
+      let el = await driver.findElement('link text', 'i am an anchor link');
+      await driver.click(el);
+      (await driver.getUrl()).should.contain('#anchor');
+      (await driver.getWindowHandles()).should.be.ok;
+    });
+
     it('should send keystrokes to specific element', async () => {
       let el = await driver.findElement('id', 'comments');
       await driver.clear(el);


### PR DESCRIPTION
Resolves https://github.com/appium/appium/issues/6506

When remote debugger receives a `PAGE_CHANGE` event, the `pageArray` is updated with a list of current URLs. This event is triggered if we navigate to a URL or reload. This event _isn't_ triggered if a fragment identifier is appended to the URL. E.g. http://google.com#blah

If we call `getUrl` after a fragment identifier is appended to the URL, the page array and the current url get out of sync, which [hinders `selectApp`](https://github.com/appium/appium-remote-debugger/blob/master/lib/remote-debugger.js#L183-L186).

All `getUrl` does is return the output of `window.location.href`

The simplest solution is to stop updating `currentUrl` when we `getUrl`.

Please review @imurchie 