### PR TITLE
mkdirp not fs.mkdirp

### DIFF
--- a/lib/commands/screenshot.js
+++ b/lib/commands/screenshot.js
@@ -2,7 +2,7 @@ import uuid from 'uuid-js';
 import B from 'bluebird';
 import path from 'path';
 import { retry } from 'asyncbox';
-import { fs } from 'appium-support';
+import { fs, mkdirp } from 'appium-support';
 import { utils } from 'appium-uiauto';
 import logger from '../logger';
 import { errors } from 'appium-base-driver';
@@ -16,7 +16,8 @@ commands.getScreenshot = async function () {
 
   let shotFolder = path.resolve(this.opts.tmpDir, 'appium-instruments/Run 1/');
   if (!(await fs.exists(shotFolder))) {
-    await fs.mkdirp(shotFolder);
+    logger.debug(`Creating folder '${shotFolder}'`);
+    await mkdirp(shotFolder);
   }
 
   let shotPath = path.resolve(shotFolder, `${shotFile}.png`);


### PR DESCRIPTION
Users have reported errors involving this (i.e., "undefined is not a function" errors).