### PR TITLE
Add ability to set initial location

### DIFF
--- a/lib/commands/general.js
+++ b/lib/commands/general.js
@@ -129,31 +129,22 @@ commands.keys = async function (keys) {
 };
 
 commands.setGeoLocation = async function (location) {
-  // TODO: check the hasOptions bit, the method signature should be location, option
+  // the spec allow for the `location` JSON object to have properties
+  // `longitude`, `latitude`, and `altitude`.
+  // iOS also supports `horizontalAccuracy`, `verticalAccuracy`, `course`, and `speed`
 
-  //let hasOptions = altitude !== null || horizontalAccuracy !== null || verticalAccuracy !== null || course !== null || speed !== null;
-  //if (hasOptions) {
-    //let options = {};
-    //if (altitude !== null) {
-      //options.altitude = altitude;
-    //}
-    //if (horizontalAccuracy !== null) {
-      //options.horizontalAccuracy = horizontalAccuracy;
-    //}
-    //if (verticalAccuracy !== null) {
-      //options.verticalAccuracy = verticalAccuracy;
-    //}
-    //if (course !== null) {
-      //options.course = course;
-    //}
-    //if (speed !== null) {
-      //options.speed = speed;
-    //}
-    //await this.uiAutoClient.sendCommand(
-      //`target.setLocationWithOptions(${JSON.stringify(coordinates)}, ${JSON.stringify(options)})`);
-  //} else {
-  await this.uiAutoClient.sendCommand(`target.setLocation(${JSON.stringify(location)})`);
-  //}
+  let coordinates = {
+    longitude: location.longitude,
+    latitude: location.latitude
+  };
+
+  let options = _.pick(location, ['altitude', 'horizontalAccuracy',
+                                  'verticalAccuracy', 'course', 'speed']);
+
+  let cmd = _.keys(options).length !== 0 ?
+              `target.setLocationWithOptions(${JSON.stringify(coordinates)}, ${JSON.stringify(options)})` :
+              `target.setLocation(${JSON.stringify(coordinates)})`;
+  await this.uiAutoClient.sendCommand(cmd);
 };
 
 commands.getWindowSize = async function (windowHandle="current") {

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -845,7 +845,8 @@ class IosDriver extends BaseDriver {
       justLoopInfinitely: false,
       autoAcceptAlerts: this.opts.autoAcceptAlerts,
       autoDismissAlerts: this.opts.autoDismissAlerts,
-      sendKeyStrategy: this.opts.sendKeyStrategy || (this.isRealDevice() ? 'grouped' : 'oneByOne')
+      sendKeyStrategy: this.opts.sendKeyStrategy || (this.isRealDevice() ? 'grouped' : 'oneByOne'),
+      initialLocation: this.opts.initialLocation
     });
     let instruments = new Instruments({
       // on real devices bundleId is always used

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -56,6 +56,19 @@ async function prepareIosOpts (opts) {
     }
     opts.safari = true;
   }
+
+  if (opts.initialLocation) {
+    if (!!opts.initialLocation.latitude || !!opts.initialLocation.longitude) {
+      logger.warn(`Ignoring invalid initial geolocation setting: ${JSON.stringify(opts.initialLocation)}`);
+      delete opts.initialLocation;
+    } else {
+      // remove anything else from the object
+      opts.initialLocation = {
+        latitude: opts.initialLocation.latitude,
+        longitude: opts.initialLocation.longitude
+      };
+    }
+  }
 }
 
 function appIsPackageOrBundle (app) {

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "appium-logger": "^2.1.0",
     "appium-remote-debugger": "^3.0.0",
     "appium-support": "^2.3.0",
-    "appium-uiauto": "^2.3.2",
+    "appium-uiauto": "^2.3.3",
     "appium-xcode": "^3.1.0",
     "asyncbox": "^2.3.1",
     "babel-runtime": "=5.8.24",

--- a/test/driver-specs.js
+++ b/test/driver-specs.js
@@ -7,6 +7,7 @@ import { withMocks } from 'appium-test-support';
 import * as teen_process from 'teen_process';
 import { fs } from 'appium-support';
 
+
 chai.should();
 chai.use(chaiAsPromised);
 
@@ -114,3 +115,56 @@ describe('getDeviceTime', withMocks({fs, teen_process}, (mocks) => {
     mocks.teen_process.verify();
   });
 }));
+
+describe('setGeoLocation', function () {
+  let uiAutoClient = {sendCommand: function () {}};
+  let driver = new IosDriver();
+  driver.uiAutoClient = uiAutoClient;
+
+  describe('parsing arguments', withMocks({uiAutoClient}, (mocks) => {
+    it('should handle latitude and longitude', async () => {
+      mocks.uiAutoClient.expects('sendCommand')
+        .withExactArgs('target.setLocation({"longitude":50,"latitude":100})');
+      await driver.setGeoLocation({longitude: 50, latitude: 100});
+      mocks.uiAutoClient.verify();
+    });
+    it('should handle latitude and longitude, plus altitude', async () => {
+      mocks.uiAutoClient.expects('sendCommand')
+        .withExactArgs('target.setLocationWithOptions({"longitude":50,"latitude":100}, {"altitude":42})');
+      await driver.setGeoLocation({longitude: 50, latitude: 100, altitude: 42});
+      mocks.uiAutoClient.verify();
+    });
+    it('should handle latitude and longitude, plus horizontalAccuracy', async () => {
+      mocks.uiAutoClient.expects('sendCommand')
+        .withExactArgs('target.setLocationWithOptions({"longitude":50,"latitude":100}, {"horizontalAccuracy":43})');
+      await driver.setGeoLocation({longitude: 50, latitude: 100, horizontalAccuracy: 43});
+      mocks.uiAutoClient.verify();
+    });
+    it('should handle latitude and longitude, plus verticalAccuracy', async () => {
+      mocks.uiAutoClient.expects('sendCommand')
+        .withExactArgs('target.setLocationWithOptions({"longitude":50,"latitude":100}, {"verticalAccuracy":44})');
+      await driver.setGeoLocation({longitude: 50, latitude: 100, verticalAccuracy: 44});
+      mocks.uiAutoClient.verify();
+    });
+    it('should handle latitude and longitude, plus course', async () => {
+      mocks.uiAutoClient.expects('sendCommand')
+        .withExactArgs('target.setLocationWithOptions({"longitude":50,"latitude":100}, {"course":45})');
+      await driver.setGeoLocation({longitude: 50, latitude: 100, course: 45});
+      mocks.uiAutoClient.verify();
+    });
+    it('should handle latitude and longitude, plus speed', async () => {
+      mocks.uiAutoClient.expects('sendCommand')
+        .withExactArgs('target.setLocationWithOptions({"longitude":50,"latitude":100}, {"speed":46})');
+      await driver.setGeoLocation({longitude: 50, latitude: 100, speed: 46});
+      mocks.uiAutoClient.verify();
+    });
+    it('should handle latitude and longitude, plus all the options', async () => {
+      mocks.uiAutoClient.expects('sendCommand')
+        .withExactArgs('target.setLocationWithOptions({"longitude":50,"latitude":100}, {"altitude":42,"horizontalAccuracy":43,"verticalAccuracy":44,"course":45,"speed":46})');
+      await driver.setGeoLocation({longitude: 50, latitude: 100, altitude: 42,
+                                   horizontalAccuracy: 43, verticalAccuracy: 44,
+                                   course: 45, speed: 46});
+      mocks.uiAutoClient.verify();
+    });
+  }));
+});


### PR DESCRIPTION
Allow the cap `initialLocation: {latitude: 4, longitude: 6}` to set the location of the test at start time.