### PR TITLE
fix the calling of deleted ncp function

### DIFF
--- a/lib/driver.js
+++ b/lib/driver.js
@@ -727,7 +727,7 @@ class IosDriver extends BaseDriver {
     logger.debug('Instruments launched. Starting poll loop for new commands.');
     if (this.opts.origAppPath) {
       logger.debug("Copying app back to its original place");
-      return await fs.ncp(this.opts.app, this.opts.origAppPath);
+      return await fs.copyFile(this.opts.app, this.opts.origAppPath);
     }
   }
 


### PR DESCRIPTION
fs.ncp is not exporting anymore. Use copyFile instead.