### PR TITLE
Port of appium 1.4 swipe action

### DIFF
--- a/lib/commands/gesture.js
+++ b/lib/commands/gesture.js
@@ -114,6 +114,89 @@ helpers.handleTap = async function (gesture) {
   return await this.uiAutoClient.sendCommand(cmd);
 };
 
+helpers.isDrag = function (gestures) {
+  return (
+      gestures.length === 4 &&
+      gestures[0].action === 'press' &&
+      gestures[1].action === 'wait' &&
+      gestures[2].action === 'moveTo' &&
+      gestures[3].action === 'release'
+  );
+};
+
+helpers.getCoordinates = async function(gesture) {
+  let el = gesture.options.element;
+
+  // defaults
+  let coordinates = {x: 0, y: 0, areOffsets: false};
+
+  // figure out the element coordinates.
+  if (el) {
+    let command = `au.getElement('${el}').rect()`;
+    let rect = await this.uiAutoClient.sendCommand(command);
+    let pos = {x: rect.origin.x, y: rect.origin.y};
+    let size = {w: rect.size.width, h: rect.size.height};
+
+    // defaults
+    let offsetX = 0;
+    let offsetY = 0;
+
+    // get the real offsets
+    if (gesture.options.x || gesture.options.y) {
+      offsetX = (gesture.options.x || 0);
+      offsetY = (gesture.options.y || 0);
+    } else {
+      offsetX = (size.w / 2);
+      offsetY = (size.h / 2);
+    }
+
+    // apply the offsets
+    coordinates.x = pos.x + offsetX;
+    coordinates.y = pos.y + offsetY;
+  } else {
+    // moveTo coordinates are passed in as offsets
+    coordinates.areOffsets = (gesture.action === 'moveTo');
+    coordinates.x = (gesture.options.x || 0);
+    coordinates.y = (gesture.options.y || 0);
+  }
+  return coordinates;
+};
+
+helpers.applyMoveToOffset = function(firstCoordinates, secondCoordinates) {
+  if (secondCoordinates.areOffsets) {
+    return {
+      x: firstCoordinates.x + secondCoordinates.x,
+      y: firstCoordinates.y + secondCoordinates.y,
+    };
+  } else {
+    return secondCoordinates;
+  }
+};
+
+helpers.handleDrag = async function (gestures) {
+  // get gestures
+  let press = gestures[0];
+  let wait = gestures[1];
+  let moveTo = gestures[2];
+
+  // get drag data
+  let pressCoordinates = await this.getCoordinates(press);
+  let duration = (parseInt(wait.options.ms, 10) / 1000);
+  let moveToCoordinates = await this.getCoordinates(moveTo);
+
+  // update moveTo coordinates with offset
+  moveToCoordinates = this.applyMoveToOffset(pressCoordinates, moveToCoordinates);
+
+  // build drag command
+  let dragCommand = (`au.dragApp(` +
+    `${pressCoordinates.x}, ${pressCoordinates.y}, ` +
+    `${moveToCoordinates.x}, ${moveToCoordinates.y}, ` +
+    `${duration})`);
+
+  // execute drag command
+  return await this.uiAutoClient.sendCommand(dragCommand);
+};
+
 commands.performTouch = async function (gestures) {
   if (this.isWebContext()) {
     throw new errors.NotYetImplementedError();
@@ -121,6 +204,8 @@ commands.performTouch = async function (gestures) {
 
   if (gestures.length === 1 && gestures[0].action === 'tap') {
     return await this.handleTap(gestures[0]);
+  } else if (this.isDrag(gestures)) {
+    return await this.handleDrag(gestures);
   }
   let touchStateObjects = await this.parseTouch(gestures);
   await this.uiAutoClient.sendCommand(`target.touch(${JSON.stringify(touchStateObjects)})`);


### PR DESCRIPTION
Fixes #150 

swipe action itself taken from lib/devices/ios/uiauto/appium/app.js as removed by commit f4a1b6fcafc51ae830132b27ff0ed44b5e253865.

extra code to get the data for the swipe action taken from other sections of the existing gesture.js in appium-ios-driver.

This is running quite well in my app tests at the moment.

I've tried to match the code style with this PR, but I didn't see any official guidelines for this repo (though I'm happy to meet standards if they are pointed out).

It also doesn't have any added unit tests.  When I ran the existing tests locally, they passed, I think, but the E2E tests definitely didn't.  I'd be happy to add some more unit tests.