### PR TITLE
Export commands

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,6 +6,7 @@ import { asyncify } from 'asyncbox';
 import { startServer } from './lib/server';
 import { IosDriver } from './lib/driver';
 import { desiredCapConstraints, desiredCapValidation } from './lib/desired-caps';
+import { commands } from './lib/commands/index';
 
 const DEFAULT_HOST = "localhost";
 const DEFAULT_PORT = 4723;
@@ -20,6 +21,6 @@ if (require.main === module) {
   asyncify(main);
 }
 
-export { IosDriver, desiredCapConstraints, desiredCapValidation };
+export { IosDriver, desiredCapConstraints, desiredCapValidation, commands };
 
 export default IosDriver;

--- a/lib/commands/index.js
+++ b/lib/commands/index.js
@@ -28,3 +28,4 @@ for (let obj of [
 }
 
 export default commands;
+export { commands };


### PR DESCRIPTION
Allow other drivers to use the code for these commands. They are mixed into this driver, and exporting them allows them to be mixed into other drivers.

There may be some tweaks needed for particular commands, but this will begin the job.