### PR TITLE
Export commands in a more granular way

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,7 +6,7 @@ import { asyncify } from 'asyncbox';
 import { startServer } from './lib/server';
 import { IosDriver } from './lib/driver';
 import { desiredCapConstraints, desiredCapValidation } from './lib/desired-caps';
-import { commands } from './lib/commands/index';
+import { commands, iosCommands } from './lib/commands/index';
 
 const DEFAULT_HOST = "localhost";
 const DEFAULT_PORT = 4723;
@@ -21,6 +21,6 @@ if (require.main === module) {
   asyncify(main);
 }
 
-export { IosDriver, desiredCapConstraints, desiredCapValidation, commands };
+export { IosDriver, desiredCapConstraints, desiredCapValidation, commands, iosCommands };
 
 export default IosDriver;

--- a/lib/commands/index.js
+++ b/lib/commands/index.js
@@ -27,5 +27,24 @@ for (let obj of [
   Object.assign(commands, obj);
 }
 
+let iosCommands = {
+  find: findExtensions,
+  element: elementExtensions,
+  logging: loggingCommands,
+  gesture: gestureExtensions,
+  alert: alertExtensions,
+  execute: executeExtensions,
+  general: generalExtensions,
+  context: contextCommands,
+  web: webCommands,
+  orientation: orientationCommands,
+  file: fileMoveCommands,
+  navigation: navigationCommands,
+  screenshot: screenshotCommands,
+  safari: safariCommands,
+  coverage: coverageCommands,
+  timeout: timeoutCommands
+};
+
 export default commands;
-export { commands };
+export { commands, iosCommands };

--- a/lib/commands/logging.js
+++ b/lib/commands/logging.js
@@ -1,7 +1,8 @@
 import _ from 'lodash';
+import { IOSLog, IOSCrashLog } from 'appium-ios-log';
 import logger from '../logger';
 
-let commands = {};
+let commands = {}, helpers = {}, extensions = {};
 
 const SUPPORTED_LOG_TYPES = {
   'syslog': 'System Logs - Device logs for iOS applications on real devices and simulators',
@@ -36,5 +37,27 @@ commands.getLog = async function (logType) {
   }
 };
 
-export { commands, SUPPORTED_LOG_TYPES };
-export default commands;
+helpers.startLogCapture = async function () {
+  if (!_.isEmpty(this.logs)) {
+    logger.warn("Trying to start iOS log capture but it's already started!");
+    return;
+  }
+  this.logs.crashlog = new IOSCrashLog();
+  this.logs.syslog = new IOSLog({
+    sim: this.sim,
+    udid: this.opts.udid
+  , showLogs: this.opts.showIOSLog
+  });
+  try {
+    await this.logs.syslog.startCapture();
+  } catch (err) {
+    logger.warn("Could not capture logs from device. Continuing without capturing logs.");
+    return;
+  }
+  await this.logs.crashlog.startCapture();
+};
+
+
+Object.assign(extensions, commands, helpers);
+export { commands, helpers, SUPPORTED_LOG_TYPES };
+export default extensions;

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -9,7 +9,6 @@ import { getSimulator, getDeviceString } from 'appium-ios-simulator';
 import { prepareBootstrap, UIAutoClient } from 'appium-uiauto';
 import { Instruments, utils as instrumentsUtils } from 'appium-instruments';
 import { retry, waitForCondition } from 'asyncbox';
-import { IOSLog, IOSCrashLog } from 'appium-ios-log';
 import commands from './commands/index';
 import { desiredCapConstraints, desiredCapValidation } from './desired-caps';
 import _iDevice from 'node-idevice';
@@ -646,26 +645,6 @@ class IosDriver extends BaseDriver {
     if (_.size(safariSettings) > 0) {
       await this.sim.updateSafariSettings(safariSettings);
     }
-  }
-
-  async startLogCapture () {
-    if (!_.isEmpty(this.logs)) {
-      logger.warn("Trying to start iOS log capture but it's already started!");
-      return;
-    }
-    this.logs.crashlog = new IOSCrashLog();
-    this.logs.syslog = new IOSLog({
-      sim: this.sim,
-      udid: this.opts.udid
-    , showLogs: this.opts.showIOSLog
-    });
-    try {
-      await this.logs.syslog.startCapture();
-    } catch (err) {
-      logger.warn("Could not capture logs from device. Continuing without capturing logs.");
-      return;
-    }
-    await this.logs.crashlog.startCapture();
   }
 
   async prelaunchSimulator () {


### PR DESCRIPTION
Allow code that is using the commands to simple assign the commands to themselves. So, for bringing in the logging commands, the code can be:

```js
import { iosCommands } from 'appium-ios-driver';


let extensions = {};
Object.assign(extensions, iosCommands.logging);

export default extensions;
```

Otherwise we need to hand-pick each method, and each method that those methods call. This way, as long as things are organized well, everything that is needed can be brought in at once.