### PR TITLE
Fix variable name for iosSdkVersion

### DIFF
--- a/lib/commands/context.js
+++ b/lib/commands/context.js
@@ -329,7 +329,7 @@ extensions.getLatestWebviewContextForTitle = async function (regExp) {
         // in the cases of Xcode < 5 (i.e., iOS SDK Version less than 7)
         // iOS 7.1, iOS 9.0 & iOS 9.1 in a webview (not in Safari)
         // we can have the url be `about:blank`
-        if (parseFloat(this.iOSSDKVersion) < 7 || parseFloat(this.iOSSDKVersion) >= 9 ||
+        if (parseFloat(this.iosSdkVersion) < 7 || parseFloat(this.iosSdkVersion) >= 9 ||
             (this.opts.platformVersion === '7.1' && this.opts.app && this.opts.app.toLowerCase() !== 'safari')) {
           matchingCtx = ctx;
         }


### PR DESCRIPTION
Everywhere else (including where it is set) the variable is `this.iosSdkVersion` not `this.iOSSDKVersion`.