### PR TITLE
Include the context element when attempting to find a descendent via XPath

### DIFF
--- a/lib/commands/find.js
+++ b/lib/commands/find.js
@@ -173,13 +173,23 @@ commands.findUIElementsByXpath = async function (selector, mult, context=null, c
   }
 
   // otherwise look up the actual element by its index path
-  let proxyCmd;
+  let methodName;
+  let methodArgs = [];
+
   if (!mult) {
-    proxyCmd = `au.getElementByIndexPath('${indexPaths[0]}')`;
+    methodName = "getElementByIndexPath";
+    methodArgs[0] = `'${indexPaths[0]}'`;
   } else {
-    let ipArrString = JSON.stringify(indexPaths);
-    proxyCmd = `au.getElementsByIndexPaths(${ipArrString})`;
+    methodName = "getElementsByIndexPaths";
+    methodArgs[0] = JSON.stringify(indexPaths);
   }
+
+  if (context) {
+    methodArgs[1] = `au.getElement('${context}')`;
+  }
+
+  let proxyCmd = `au.${methodName}(${methodArgs.join(", ")})`;
+
   // having index paths means we think elements should be there. Sometimes
   // uiauto lags in enabling us to get elements, so we retry a few times if
   // it can't find elements we know should be there. see uiauto code

--- a/test/e2e/uicatalog/find-specs.js
+++ b/test/e2e/uicatalog/find-specs.js
@@ -327,6 +327,11 @@ describe('uicatalog - find -', function () {
         (await driver.getText(el)).should.equal("X Button");
       });
 
+      it('should find an element within itself', async () => {
+        let e1 = await driver.findElement('xpath', "//UIATableCell[@name='X Button']");
+        let e2 = await driver.findElementFromElement('xpath', "//UIAButton[1]", e1);
+        (await driver.getText(e2)).should.equal("X Button");
+      });
     });
 
     describe('duplicate text field', function () {


### PR DESCRIPTION
All requests to find elements from an element using the xpath strategy are currently failing. It turns out that we are never passing the context element to uiauto's "getElement(s)ByIndexPath" methods.

This PR includes both the fix for finding descendent elements using XPath and a corresponding e2e test.