### PR TITLE
Make sure the url bar element is there

### DIFF
--- a/lib/commands/context.js
+++ b/lib/commands/context.js
@@ -421,7 +421,7 @@ extensions.typeAndNavToUrl = async function () {
     // get the last address element and set the url
     // this is flakey on certain systems so we retry until we get something
     let elId = await retryInterval(5, 1000, async () => {
-      let el = _.first(await this.findElements('class name', 'UIATextField'));
+      let el = await this.findElement('class name', 'UIATextField');
       return el.ELEMENT;
     });
     await this.setValueImmediate(this.getCurrentUrl(), elId);


### PR DESCRIPTION
The first element of `findElements` will be the same as the element from `findElement`, and we will get the error thrown so the retry will work.

Fixes #182