### PR TITLE
Stop uiauto and instruments after Safari Browser launching

### DIFF
--- a/lib/driver.js
+++ b/lib/driver.js
@@ -149,23 +149,30 @@ class IosDriver extends BaseDriver {
     return [sessionId, this.caps];
   }
 
-  async stop () {
-    this.ready = false;
-
+  async stopUIAutoClient () {
     if (this.uiAutoClient) {
       await this.uiAutoClient.shutdown();
+      this.uiAutoClient = null;
     }
+  }
 
+  async stopInstruments () {
     if (this.instruments) {
       try {
         await this.instruments.shutdown();
       } catch (err) {
         logger.error(`Instruments didn't shut down. ${err}`);
       }
+      this.instruments = null;
     }
+  }
 
-    this.uiAutoClient = null;
-    this.instruments = null;
+  async stop () {
+    this.ready = false;
+
+    await this.stopUIAutoClient();
+    await this.stopInstruments();
+
     this.realDevice = null;
 
     // postcleanup
@@ -497,6 +504,12 @@ class IosDriver extends BaseDriver {
       }
       logger.debug('Waiting for initial webview');
       await this.navToInitialWebview();
+      if (this.isRealDevice()) {
+        // we don't need UIAutoClient and Instruments any more (on real device),
+        // should stop them to avoid 'Abnormal Instruments error' due to the command timeout.
+        await this.stopUIAutoClient();
+        await this.stopInstruments();
+      }
       condFn = async () => {
         return true;
       };


### PR DESCRIPTION
We fixed https://github.com/appium/appium-instruments/issues/79

The root cause is after the instruments start SafariLauncher to launch the Safari Browser, it still exist and waiting for next command with timeout (3600s)
https://github.com/appium/appium-uiauto/blob/master/uiauto/lib/commands.js#L79

So if we do long test script (more than 1 hour) the timeout was reached and it throws "Abnormal Instruments termination!" and then Appium ends the session
We can reproduce (100%) with this test https://gist.github.com/nghiadhd/ae108085df5c16781271f34af0038589#file-long-run-js

We expect the instrument should be shutdown after Safari Browser launching
