### PR TITLE
Retry when unable to find URL text field for Safari

### DIFF
--- a/lib/commands/context.js
+++ b/lib/commands/context.js
@@ -386,6 +386,11 @@ extensions.navToInitialWebview = async function () {
   }
 };
 
+async function openNewPage() {
+  let newPageButton = await this.findElement('xpath', "//UIAButton[contains(@name,'New page')]");
+  await this.nativeTap(newPageButton.ELEMENT);
+}
+
 extensions.typeAndNavToUrl = async function () {
   this.setCurrentUrl(this.caps.safariInitialUrl || `http://127.0.0.1:${this.opts.port}/welcome`);
 
@@ -410,8 +415,7 @@ extensions.typeAndNavToUrl = async function () {
 
         // generally this means that Safari is in page viewing mode
         // so try to open a new page and then redo the navigation
-        let newPageButton = await this.findElement('xpath', "//UIAButton[contains(@name,'New page')]");
-        await this.nativeTap(newPageButton.ELEMENT);
+        await openNewPage();
         return await navigate();
       } else {
         throw err;
@@ -419,12 +423,15 @@ extensions.typeAndNavToUrl = async function () {
     }
 
     // get the last address element and set the url
-    // this is flakey on certain systems so we retry until we get something
-    let elId = await retryInterval(5, 1000, async () => {
+    try {
       let el = await this.findElement('class name', 'UIATextField');
-      return el.ELEMENT;
-    });
-    await this.setValueImmediate(this.getCurrentUrl(), elId);
+      await this.setValueImmediate(this.getCurrentUrl(), el);
+    } catch (err) {
+      // this is flakey on certain systems so we retry until we get something
+      // ios sims: safari opens but the text field can't be found
+      if (tries++ >= MAX_TRIES) throw err;
+      return await navigate();
+    }
 
     // make it happen
     try {


### PR DESCRIPTION
iOS simulators sometimes crash when trying to find the URL text field. Retry the entire process.

I was seeing the issue several times (more than 50%), though the problem seemed to come and go in waves. After this change, I haven't seen the issue. I believe this fixes https://github.com/appium/appium-ios-driver/issues/182

My setup FWIW:
* Macbook Pro
* OSX El Capitan
* XCode 7
* iOS 9.3 simulator + instruments-without-delay
* Appium 1.5.3
* Node 6.5.0