### PR TITLE
Allow fullReset and settings change

### DIFF
--- a/lib/settings.js
+++ b/lib/settings.js
@@ -66,9 +66,6 @@ async function setPreferences (sim, opts, safari = false) {
   if (!needToSetPrefs && !needToSetSafariPrefs) {
     logger.debug("No iOS / app preferences to set");
     return;
-  } else if (opts.fullReset) {
-    let msg = "Cannot set preferences because a full-reset was requested";
-    logger.errorAndThrow(msg);
   }
 
   logger.debug("Setting iOS and app preferences");


### PR DESCRIPTION
The flow is now such that we do the reset first, and then set the settings. So this error is not necessary. Fixes #186