### PR TITLE
Add clearSystemFiles cap to delete cache and logs at the end of the session

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,6 +9,7 @@ import { desiredCapConstraints, desiredCapValidation } from './lib/desired-caps'
 import { commands, iosCommands } from './lib/commands/index';
 import * as settings from './lib/settings';
 import * as device from './lib/device';
+import utils from './lib/utils';
 
 
 const DEFAULT_HOST = "localhost";
@@ -25,6 +26,6 @@ if (require.main === module) {
 }
 
 export { IosDriver, desiredCapConstraints, desiredCapValidation, commands,
-         iosCommands, settings, device, defaultServerCaps };
+         iosCommands, settings, device, defaultServerCaps, utils };
 
 export default IosDriver;

--- a/lib/commands/gesture.js
+++ b/lib/commands/gesture.js
@@ -341,7 +341,7 @@ commands.parseTouch = async function (gestures) {
       let offset = 0.2;
       if (gesture.action === 'wait') {
         if (typeof gesture.options.ms !== 'undefined' || gesture.options.ms !== null) {
-          offset = (parseInt(gesture.options.ms) / 1000);
+          offset = (parseInt(gesture.options.ms, 10) / 1000);
         }
       }
       let touchStateObject = {

--- a/lib/desired-caps.js
+++ b/lib/desired-caps.js
@@ -89,7 +89,10 @@ const desiredCapConstraints = {
   },
   appName: {
     isString: true
-  }
+  },
+  clearSystemFiles: {
+    isBoolean: true
+  },
 };
 
 function desiredCapValidation (caps) {

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -40,6 +40,11 @@ const defaultServerCaps = {
   networkConnectionEnabled: false,
 };
 
+const LOG_LOCATIONS = [
+  path.resolve('/', 'Library', 'Caches', 'com.apple.dt.instruments'),
+  path.resolve(process.env.HOME, 'Library', 'Logs', 'CoreSimulator'),
+];
+
 class IosDriver extends BaseDriver {
   resetIos () {
     this.appExt = ".app";
@@ -186,6 +191,12 @@ class IosDriver extends BaseDriver {
     logger.debug("Deleting ios session");
 
     await this.stop();
+
+    if (this.opts.clearSystemFiles) {
+      await utils.clearLogs(LOG_LOCATIONS);
+    } else {
+      logger.debug('Not clearing log files. Use `clearSystemFiles` capability to turn on.');
+    }
 
     if (this.isRealDevice()) {
       await runRealDeviceReset(this.realDevice, this.opts);

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -233,7 +233,29 @@ function unwrapEl (el) {
   return el;
 }
 
+async function clearLogs (locations) {
+  logger.debug('Clearing log files');
+  for (let location of locations) {
+    if (await fs.exists(location)) {
+      let size;
+      try {
+        let {stdout} = await exec('du', ['-sh', location]);
+        size = stdout.trim().split(/\s+/)[0];
+      } catch (ign) {}
+      try {
+        /* jshint ignore:start */
+        logger.debug(`Deleting '${location}'. ${size ? `Freeing ${size}.` : ''}`);
+        /* jshint ignore:end */
+        await fs.rimraf(location);
+      } catch (err) {
+        logger.warn(`Unable to delete '${location}': ${err.message}`);
+      }
+    }
+  }
+  logger.debug('Finished clearing log files');
+}
+
 export default { rootDir, removeInstrumentsSocket, getAndCheckXcodeVersion, prepareIosOpts,
   appIsPackageOrBundle, getAndCheckIosSdkVersion,  detectUdid, parseLocalizableStrings,
   setBundleIdFromApp, shouldPrelaunchSimulator, setDeviceTypeInInfoPlist,
-  getSimForDeviceString, unwrapEl };
+  getSimForDeviceString, unwrapEl, clearLogs };


### PR DESCRIPTION
Add a capability, `clearLogs`, to indicate that the cache and log files should be deleted at the end of the session.

Address https://github.com/appium/appium/issues/6952