### PR TITLE
Add driver version to logs

### DIFF
--- a/lib/driver.js
+++ b/lib/driver.js
@@ -17,6 +17,7 @@ import { install, needsInstall, SAFARI_LAUNCHER_BUNDLE } from './safari-launcher
 import { setLocale, setPreferences } from './settings';
 import { runSimulatorReset, isolateSimulatorDevice, checkSimulatorAvailable,
          moveBuiltInApp, getAdjustedDeviceName, endSimulator, runRealDeviceReset } from './device';
+import { version } from '../../package.json'; // eslint-disable-line import/no-unresolved
 
 
 // promisify _iDevice
@@ -94,6 +95,8 @@ class IosDriver extends BaseDriver {
 
   constructor (opts, shouldValidateCaps) {
     super(opts, shouldValidateCaps);
+
+    logger.debug(`IosDriver version: ${version}`);
 
     this.desiredCapConstraints = desiredCapConstraints;
     this.resetIos();


### PR DESCRIPTION
Make it easier to tell what people are running when they provide logs.