### PR TITLE
Fix reset on real device

### DIFF
--- a/lib/device.js
+++ b/lib/device.js
@@ -102,7 +102,7 @@ async function clearAppData  (sim, opts, keepApp) {
 
 async function resetRealDevice (device, opts) {
   if (opts.bundleId && opts.fullReset) {
-    let bundleId = this.opts.bundleId;
+    let bundleId = opts.bundleId;
     logger.debug(`Full reset requested. Will try to uninstall the app '${bundleId}'.`);
     try {
       await device.remove(bundleId);

--- a/test/e2e/safari/windows-frame-specs.js
+++ b/test/e2e/safari/windows-frame-specs.js
@@ -56,6 +56,7 @@ describe(`safari - windows and frames (${env.DEVICE})`, function () {
 });
 
 describe(`safari - windows and frames (${env.DEVICE}) - without safariAllowPopups`, function () {
+  if (process.env.TRAVIS) this.timeout(240000);
   const driver = setup(this, {
     browserName: 'safari',
     safariAllowPopups: false


### PR DESCRIPTION
When these methods were pulled off the object, this `this` slipped through.

Fixes https://github.com/appium/appium/issues/7092