### PR TITLE
Fix some logging for close/launch

### DIFF
--- a/lib/commands/general.js
+++ b/lib/commands/general.js
@@ -81,21 +81,23 @@ commands.lock = async function (secs) {
 };
 
 commands.closeApp = async function () {
+  let appName = this.opts.app || this.opts.bundleId;
   try {
     await this.stop();
-    log.info(`Successfully closed the [${this.opts.app}] app.`);
+    log.info(`Successfully closed the '${appName}' app.`);
   } catch (err) {
-    log.warn(`Something went wrong while closing the [${this.opts.app}] app.`);
+    log.warn(`Something went wrong while closing the '${appName}' app.`);
     throw err;
   }
 };
 
 commands.launchApp = async function () {
+  let appName = this.opts.app || this.opts.bundleId;
   try {
     await this.start();
-    log.info(`Successfully launched the [${this.opts.app}] app.`);
+    log.info(`Successfully launched the '${appName}' app.`);
   } catch (err) {
-    log.warn(`Something went wrong while launching the [${this.opts.app}] app.`);
+    log.warn(`Something went wrong while launching the '${appName}' app.`);
     throw err;
   }
 };


### PR DESCRIPTION
If we have `bundleId` instead of `app` the logs show `undefined`.