### PR TITLE
Accepts customSSLCert as a capability

### DIFF
--- a/lib/desired-caps.js
+++ b/lib/desired-caps.js
@@ -93,6 +93,9 @@ const desiredCapConstraints = {
   clearSystemFiles: {
     isBoolean: true
   },
+  customSSLCert: {
+    isString: true
+  },
 };
 
 function desiredCapValidation (caps) {

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -5,7 +5,7 @@ import path from 'path';
 import _ from 'lodash';
 import B from 'bluebird';
 import { fs } from 'appium-support';
-import { getSimulator } from 'appium-ios-simulator';
+import { getSimulator, installSSLCert, uninstallSSLCert } from 'appium-ios-simulator';
 import { prepareBootstrap, UIAutoClient } from 'appium-uiauto';
 import { Instruments, utils as instrumentsUtils } from 'appium-instruments';
 import { retry, waitForCondition } from 'asyncbox';
@@ -174,6 +174,10 @@ class IosDriver extends BaseDriver {
       }
     }
 
+    if (this.caps.customSSLCert && !this.isRealDevice()) {
+      uninstallSSLCert(this.caps.customSSLCert, this.iosSimUdid);
+    }
+
     this.uiAutoClient = null;
     this.instruments = null;
     this.realDevice = null;
@@ -312,6 +316,10 @@ class IosDriver extends BaseDriver {
       if (this.caps.app) {
         await utils.setDeviceTypeInInfoPlist(this.opts.app, dString);
       }
+    }
+
+    if (this.caps.customSSLCert && !this.isRealDevice()) {
+      installSSLCert(this.caps.customSSLCert, iosSimUdid);
     }
 
     await runSimulatorReset(this.sim, this.opts, this.keepAppToRetainPrefs);

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -175,7 +175,7 @@ class IosDriver extends BaseDriver {
     }
 
     if (this.caps.customSSLCert && !this.isRealDevice()) {
-      uninstallSSLCert(this.caps.customSSLCert, this.iosSimUdid);
+      await uninstallSSLCert(this.caps.customSSLCert, this.iosSimUdid);
     }
 
     this.uiAutoClient = null;
@@ -319,7 +319,7 @@ class IosDriver extends BaseDriver {
     }
 
     if (this.caps.customSSLCert && !this.isRealDevice()) {
-      installSSLCert(this.caps.customSSLCert, iosSimUdid);
+      await installSSLCert(this.caps.customSSLCert, iosSimUdid);
     }
 
     await runSimulatorReset(this.sim, this.opts, this.keepAppToRetainPrefs);

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "appium-cookies": "^1.1.0",
     "appium-instruments": "^3.8.2",
     "appium-ios-log": "^1.2.0",
-    "appium-ios-simulator": "^1.7.0",
+    "appium-ios-simulator": "^1.9.0",
     "appium-logger": "^2.1.0",
     "appium-remote-debugger": "^3.0.0",
     "appium-support": "^2.3.0",
@@ -78,10 +78,13 @@
     "eslint-plugin-mocha": "^3.0.0",
     "eslint-plugin-promise": "^3.3.1",
     "gulp": "^3.9.1",
+    "https": "^1.0.0",
     "node-uuid": "^1.4.7",
+    "pem": "^1.8.3",
     "pre-commit": "^1.1.3",
     "sample-apps": "^2.0.4",
     "sinon": "^1.17.4",
-    "unorm": "^1.4.1"
+    "unorm": "^1.4.1",
+    "wd": "^1.0.0"
   }
 }

--- a/test/e2e/safari/webview/ssl-specs.js
+++ b/test/e2e/safari/webview/ssl-specs.js
@@ -1,0 +1,34 @@
+import desired from './desired';
+import B from 'bluebird';
+import https from 'https';
+import setup from '../../setup-base';
+
+const pem = B.promisifyAll(require('pem'));
+
+describe('When accessing an HTTPS encrypted site in Safari', async function () {
+  let sslServer;
+
+  before(async () => {
+    // Create an HTTPS server with a random pem certificate
+    let privateKey = await pem.createPrivateKeyAsync();
+    let keys = await pem.createCertificateAsync({days:1, selfSigned: true, serviceKey: privateKey.key});
+    let pemCertificate = keys.certificate;
+
+    sslServer = https.createServer({key: keys.serviceKey, cert: pemCertificate}, function (req, res) {
+      res.end('Arbitrary text');
+    }).listen(9758);
+    desired.customSSLCert = pemCertificate;
+  });
+
+  const driver = setup(this, desired, {noReset: true}).driver;
+
+  after(async () => {
+    await sslServer.close();
+  });
+
+  it('should be able to access it as long the PEM certificate is provided as a capability', async () => {
+    await B.delay(500);
+    await driver.setUrl('https://localhost:9758');
+    (await driver.getPageSource()).should.include('Arbitrary text');
+  });
+});


### PR DESCRIPTION
-Updated driver.js to installSSLCert when it's using an IOS Simulator and customSSLCert was provided.
-Updated appium-ios-simulator to 1.9.0 which has installSSLCert and uninstallSSLCert methods
-Wrote a spec that sets up a temporary https site with a random PEM certificate to test that it can open said site
-Make customSSLCert part of desired caps