### PR TITLE
Only call this.remote.pageLoad() when necessary in the appium-ios-driver

### DIFF
--- a/lib/commands/context.js
+++ b/lib/commands/context.js
@@ -299,13 +299,13 @@ extensions.onPageChange = async function (pageChangeNotification) {
       let needsPageLoad = (() => {
         let item = (arr) => {
           return _.filter(arr, (obj) => {
-            return obj.id === this.curContext;
+            return obj === this.curContext;
           })[0];
         };
 
         // need to map the page ids to context ids
         let contextArray = _.map(pageArray, (arr) => {
-          return {id: `${appIdKey}.${arr.id}`};
+          return `${appIdKey}.${arr.id}`;
         });
         return !_.isEqual(item(this.contexts), item(contextArray));
       })();


### PR DESCRIPTION
Fixed the check of needsPageLoad: this.contexts contains elements of the form &lt;appId&gt;.&lt;pageId&gt; and therefore we need to make sure that contextArray contains elements of the same structure