### PR TITLE
Do not check page update when we are not connected

### DIFF
--- a/lib/commands/context.js
+++ b/lib/commands/context.js
@@ -238,6 +238,10 @@ extensions.onPageChange = async function (pageChangeNotification) {
     logger.debug('We are in the middle of selecting a page, ignoring');
     return;
   }
+  if (!this.remote.appIdKey) {
+    logger.debug('We have not yet connected, ignoring');
+    return;
+  }
 
   let {appIdKey, pageArray} = pageChangeNotification;
 


### PR DESCRIPTION
We cannot control when page change events come in, so make sure that we don't try to do anything with them when we are not yet connected.