### PR TITLE
Actually remove ios-app-utils

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,6 +1,6 @@
 import { fs, plist } from 'appium-support';
 import xcode from 'appium-xcode';
-import { extractBundleId } from 'ios-app-utils';
+import { extractBundleId } from './app-utils';
 import logger from './logger';
 import path from 'path';
 import _ from 'lodash';

--- a/package.json
+++ b/package.json
@@ -37,7 +37,6 @@
     "bluebird": "^2.10.2",
     "continuation-local-storage": "^3.1.7",
     "date-utils": "^1.2.21",
-    "ios-app-utils": "^1.1.0",
     "js2xmlparser2": "^0.2.0",
     "lodash": "^4.13.1",
     "node-idevice": "^0.1.6",


### PR DESCRIPTION
It appears I didn't actually strip out `ios-app-utils` from the driver, though all the functionality is internal now.