### PR TITLE
Fix - Wrong format of ios crashlog

### DIFF
--- a/lib/device-log/ios-crash-log.js
+++ b/lib/device-log/ios-crash-log.js
@@ -25,7 +25,7 @@ class IOSCrashLog {
       let filename = path.resolve(this.logDir, file);
       let stat = await fs.stat(filename);
       return {
-        timestamp: stat.ctime,
+        timestamp: stat.ctime.getTime(),
         level: 'ALL',
         message: await fs.readFile(filename, 'utf8')
       };


### PR DESCRIPTION
## Problem

Selenium fails to parse ios crash log:

```
2016-08-29T14:46:27,427 ERROR c.t.c.MainProcess.execute(61) - Error executing main process
java.lang.ClassCastException: java.lang.String cannot be cast to java.lang.Long
        at org.openqa.selenium.remote.RemoteLogs.getRemoteEntries(RemoteLogs.java:88) ~[x.jar:?]
        at org.openqa.selenium.remote.RemoteLogs.get(RemoteLogs.java:77) ~[x.jar:?]
```

## Cause

```stat.ctime``` returns ```Date``` object that will be converted into string like ```2017-02-04T11:15:08.264Z``` on json serialization

but selenium driver expects ```Long``` unixtime in ```timestamp``` field of log entity

## Solution

send ```Number``` in ```timestamp```

P.S. ```ios-log``` and android's ```logcat``` already sends ```timestamp``` in the right format:

```
          let logObj = {
            timestamp: Date.now(),
            level: 'ALL',
            message: log
          };
```

