### PR TITLE
changing 127.0.0.1 to appium's listening address

### DIFF
--- a/lib/commands/context.js
+++ b/lib/commands/context.js
@@ -396,7 +396,8 @@ async function openNewPage () {
 }
 
 extensions.typeAndNavToUrl = async function () {
-  this.setCurrentUrl(this.caps.safariInitialUrl || `http://127.0.0.1:${this.opts.port}/welcome`);
+  let address = this.opts.address ? this.opts.address : '127.0.0.1';
+  this.setCurrentUrl(this.caps.safariInitialUrl || `http://${address}:${this.opts.port}/welcome`);
 
   let tries = 0;
   const MAX_TRIES = 2;


### PR DESCRIPTION
While testing safari on ios, we found that when initializing driver appium tries to open url: `http://127.0.0.1:4723/welcome`. It is ok if you are listening on default address (0.0.0.0), but if you listen on another ip by using `-a` parameter, appium fails to open this url.

Changes in this PR solve this issue.