### PR TITLE
Allow real device safari tests to pass in bundleId for SafariLauncher

### DIFF
--- a/lib/driver.js
+++ b/lib/driver.js
@@ -265,8 +265,8 @@ class IosDriver extends BaseDriver {
               logger.debug('SafariLauncher not found, building...');
               await install();
             }
+            this.opts.bundleId = SAFARI_LAUNCHER_BUNDLE;
           }
-          this.opts.bundleId = SAFARI_LAUNCHER_BUNDLE;
         }
       } else if (this.opts.bundleId &&
                  utils.appIsPackageOrBundle(this.opts.bundleId) &&

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -41,8 +41,9 @@ async function prepareIosOpts (opts) {
       (opts.bundleId || '').toLowerCase() === SAFARI_BUNDLE) {
     // preparing a safari session
     if (opts.udid) {
-      opts.app = SAFARI_LAUNCHER_APP_FILE;
-      opts.bundleId = SAFARI_LAUNCHER_BUNDLE;
+      // on a real device
+      opts.app = opts.app || SAFARI_LAUNCHER_APP_FILE;
+      opts.bundleId = opts.bundleId || SAFARI_LAUNCHER_BUNDLE;
     } else {
       if (parseFloat(opts.platformVersion) <= 8) {
         // make sure args.app has something in it so we get to the right spots


### PR DESCRIPTION
In recent versions of Xcode Apple has made it difficult to build some apps for real devices. Particularly with free accounts, where you cannot create a wildcard certificate, it is necessary to change the bundle id of the apps being built, which makes it impossible to build `SafariLauncher`. Currently we insist that the `bundleId` for `SafariLauncher` be `com.bytearc.SafariLauncher`. This PR removes that requirement, allowing the user to pass in the `bundleId` for a real device Safari test, so that `SafariLauncher` can be manually configured.