### PR TITLE
Make sure we don't call a non-function

### DIFF
--- a/lib/commands/web.js
+++ b/lib/commands/web.js
@@ -180,7 +180,7 @@ extensions.findWebElementOrElements = async function (strategy, selector, many, 
   try {
     await this.implicitWaitForCondition(doFind);
   } catch (err) {
-    if (err.message && err.message.match(/Condition unmet/)) {
+    if (err.message && _.isFunction(err.message.match) && err.message.match(/Condition unmet/)) {
       // condition was not met setting res to empty array
       element = [];
     } else {


### PR DESCRIPTION
There have been reports of an error getting in that has something in its `message` property but no `match` method on it. Not sure of the problem, but this will allow the _actual_ issue to surface.

Sample logs:
```
14:32:40	VERBOSE:	[35m[HTTP][39m [37m-->[39m [37mPOST[39m [37m/wd/hub/session/f1c88682-9591-42cd-b564-1550c0d878d6/element[39m [90m{"using":"id","value":"q1a1"}[39m
14:32:40	VERBOSE:	[debug] [35m[MJSONWP][39m Calling AppiumDriver.findElement() with args: ["id","q1a1","f1c88682-9591-42cd-b564-1550c0d878d6"]
14:32:40	VERBOSE:	[debug] [35m[XCUITest][39m Executing command 'findElement'
14:32:40	VERBOSE:	[debug] [35m[BaseDriver][39m Valid locator strategies for this request: xpath, id, name, class name, -ios predicate string, accessibility id
14:32:40	VERBOSE:	[debug] [35m[BaseDriver][39m Waiting up to 0 ms for condition
14:32:40	VERBOSE:	[debug] [35m[RemoteDebugger][39m Executing 'find_element' atom in default context
14:32:40	VERBOSE:	[debug] [35m[RemoteDebugger][39m Sending javascript command (function(){return function(){var l=this;functi...
14:32:40	VERBOSE:	[debug] [35m[RemoteDebugger][39m Sending WebKit data: {"method":"Runtime.evaluate...
14:32:40	VERBOSE:	[debug] [35m[RemoteDebugger][39m Receiving WebKit data: {"result":{"result":{"type"...
14:32:40	VERBOSE:	[debug] [35m[RemoteDebugger][39m Found handler for message '1'
14:32:40	VERBOSE:	[debug] [35m[iOS][39m Error received while executing atom: [object Object]
14:32:40	VERBOSE:	[35m[MJSONWP][39m Encountered internal error running command: TypeError: context$1$0.t0.message.match is not a function
14:32:40	VERBOSE:	    at XCUITestDriver.callee$0$0$ (../../../lib/commands/web.js:183:36)
14:32:40	VERBOSE:	    at tryCatch (/Users/ios/appium/appium/1.6.3/node_modules/babel-runtime/regenerator/runtime.js:67:40)
14:32:40	VERBOSE:	    at GeneratorFunctionPrototype.invoke [as _invoke] (/Users/ios/appium/appium/1.6.3/node_modules/babel-runtime/regenerator/runtime.js:315:22)
14:32:40	VERBOSE:	    at GeneratorFunctionPrototype.prototype.(anonymous function) [as throw] (/Users/ios/appium/appium/1.6.3/node_modules/babel-runtime/regenerator/runtime.js:100:21)
14:32:40	VERBOSE:	    at GeneratorFunctionPrototype.invoke (/Users/ios/appium/appium/1.6.3/node_modules/babel-runtime/regenerator/runtime.js:136:37)
14:32:40	VERBOSE:	    at run (/Users/ios/appium/appium/1.6.3/node_modules/core-js/library/modules/es6.promise.js:108:47)
14:32:40	VERBOSE:	    at /Users/ios/appium/appium/1.6.3/node_modules/core-js/library/modules/es6.promise.js:119:28
14:32:40	VERBOSE:	    at flush (/Users/ios/appium/appium/1.6.3/node_modules/core-js/library/modules/$.microtask.js:19:5)
14:32:40	VERBOSE:	    at _combinedTickCallback (internal/process/next_tick.js:67:7)
14:32:40	VERBOSE:	    at process._tickCallback (internal/process/next_tick.js:98:9)
14:32:40	VERBOSE:	[35m[HTTP][39m [37m<-- POST /wd/hub/session/f1c88682-9591-42cd-b564-1550c0d878d6/element [39m[31m500[39m [90m526 ms - 217[39m [90m[39m
```