### PR TITLE
Fixed defect in retryInterval, improved logging

### DIFF
--- a/lib/desired-caps.js
+++ b/lib/desired-caps.js
@@ -96,9 +96,6 @@ const desiredCapConstraints = {
   customSSLCert: {
     isString: true
   },
-  startIWDP: {
-    isBoolean: true
-  },
 };
 
 function desiredCapValidation (caps) {

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -352,7 +352,6 @@ class IosDriver extends BaseDriver {
     await this.onInstrumentsLaunch();
     await this.configureBootstrap();
     await this.setBundleId();
-    await this.startIWDP();
     await this.setInitialOrientation();
     await this.initAutoWebview();
     await this.waitForAppLaunched();

--- a/lib/iwdp.js
+++ b/lib/iwdp.js
@@ -3,10 +3,12 @@ import EventEmitter from 'events';
 import logger from './logger';
 import request from 'request-promise';
 import { retryInterval } from 'asyncbox';
-import { fs } from 'appium-support';
+import { fs, logger as baseLogger } from 'appium-support';
 
 const IWDP_CMD = 'ios_webkit_debug_proxy';
 const MAX_RETRIES = 10;
+
+let iwdpLogger = baseLogger.getLogger('IWDP');
 
 class IWDP extends EventEmitter {
 
@@ -20,8 +22,9 @@ class IWDP extends EventEmitter {
   }
 
   createIWDPProcess () {
-    let process = new SubProcess(IWDP_CMD, ['--config', `${this.udid}:${this.port},:${this.port + 1}-${this.port + 101}`]); // (see https://github.com/google/ios-webkit-debug-proxy for reference)
+    let process = new SubProcess(IWDP_CMD, ['-c', `${this.udid}:${this.port}`, '-d']); // (see https://github.com/google/ios-webkit-debug-proxy for reference)
     process.on('exit', () => this.onExit());
+    process.on('lines-stderr', iwdpLogger.error);
     return process;
   }
 
@@ -44,6 +47,7 @@ class IWDP extends EventEmitter {
       logger.errorAndThrow(`'ios_webkit_debug_proxy' not installed on this machine. Try 'brew install ios-webkit-debug-proxy`);
     }
     
+    logger.debug(`Starting ios_webkit_debug_proxy at port ${this.port} on device ${this.udid}`);
     await this.process.start(0);
 
     // Retry pinging the iwdp server until it's ready
@@ -51,6 +55,9 @@ class IWDP extends EventEmitter {
       await retryInterval(20, 500, async () => await request(this.endpoint));
       this.emit('start');
     } catch (ign) {
+      try {
+        await this.process.stop();
+      } catch (ign2) { }
       logger.errorAndThrow(`Timed out waiting for ios_webkit_debug_proxy to open`);
     }
   }

--- a/test/unit/driver-specs.js
+++ b/test/unit/driver-specs.js
@@ -7,10 +7,7 @@ import { withMocks } from 'appium-test-support';
 import * as teen_process from 'teen_process';
 import { fs } from 'appium-support';
 import xcode from 'appium-xcode';
-import sinon from 'sinon';
-import request from 'request-promise';
 
-let expect = chai.expect;
 chai.should();
 chai.use(chaiAsPromised);
 
@@ -85,47 +82,6 @@ describe('driver', () => {
         await driver.asyncScriptTimeout(to + 20);
         driver.asyncWaitMs.should.equal(to + 20);
       });
-    });
-  });
-
-  describe('IWDP runner', async () => {
-    let driver, stub;
-
-    beforeEach(() => {
-      driver = new IosDriver();
-      stub = sinon.stub(driver, 'isRealDevice', () => true);
-    });
-
-    afterEach(() => {
-      stub.restore();
-    });
-
-    it('should not start IWDP server if startIWDP !== true', async () => {
-      await driver.startIWDP();
-      expect(driver.iwdpServer).to.be.undefined;
-      await driver.stopIWDP();
-    });
-
-    it('should start IWDP server if "startIWDP=true" and then close it when stopIWDP is called', async () => {
-      driver.opts.startIWDP = true;
-      await driver.startIWDP();
-      let endpoint = driver.iwdpServer.endpoint;
-      await request(endpoint).should.eventually.have.string('<html');
-      await driver.stopIWDP();
-      await request(endpoint).should.eventually.be.rejected;
-      expect(driver.iwdpServer).to.be.undefined;
-    });
-
-    it('should start IWDP server at the port specified in opts.webkitDebugProxyPort', async () => {
-      driver.opts.webkitDebugProxyPort = 56789;
-      driver.opts.startIWDP = true;
-      await driver.startIWDP();
-      let endpoint = driver.iwdpServer.endpoint;
-      endpoint.should.have.string('56789');
-      await request(endpoint).should.eventually.have.string('<html');
-      await driver.stopIWDP();
-      await request(endpoint).should.eventually.be.rejected;
-      expect(driver.iwdpServer).to.be.undefined;
     });
   });
 });


### PR DESCRIPTION
* Retrying endpoints works when hitting localhost:27754 which is the endpoint for device. localhost:27753 is flakey
* Added logging for IWDP and log that says when IWDP starts
* Calls process.stop() on IWDP if it fails, just in case the process actually started and we don't want to leave it running
* Removed startIWDP capability (that goes in XCUITestDriver)

(please reveiw @imurchie @jlipps)