### PR TITLE
Change max log size to be controlled by a simple constant

### DIFF
--- a/lib/device-log/ios-log.js
+++ b/lib/device-log/ios-log.js
@@ -4,7 +4,6 @@ import logger from './logger';
 import { fs, mkdirp } from 'appium-support';
 import xcode from 'appium-xcode';
 import { SubProcess } from 'teen_process';
-import v8 from 'v8'; //eslint-disable-line import/no-unresolved
 
 // Date-Utils: Polyfills for the Date object
 require('date-utils');
@@ -13,6 +12,8 @@ require('date-utils');
 const START_TIMEOUT = 10000;
 const DEVICE_CONSOLE_PATH = path.resolve(__dirname, '..', '..', '..', 'build', 'deviceconsole');
 const SYSTEM_LOG_PATH = '/var/log/system.log';
+// We keep only the most recent log entries to avoid out of memory error
+const MAX_LOG_ENTRIES_COUNT = 10000;
 
 class IOSLog {
   constructor (opts) {
@@ -22,7 +23,6 @@ class IOSLog {
 
     this.proc = null;
     this.logs = [];
-    this.logsSize = this._objectSize(this.logs);
     this.logRow = '';
     this.logIdxSinceLastRequest = -1;
   }
@@ -149,53 +149,6 @@ class IOSLog {
     this.proc = null;
   }
 
-  _objectSize (obj) {
-    let objectList = [];
-    let stack = [obj];
-    let bytes = 0;
-
-    while (stack.length) {
-      let value = stack.pop();
-      if (typeof value === 'boolean') {
-        bytes += 4;
-      } else if (typeof value === 'string') {
-        bytes += value.length * 2;
-      } else if (typeof value === 'number') {
-        bytes += 8;
-      } else if (typeof value === 'object' && objectList.indexOf(value) === -1) {
-        objectList.push(value);
-        for (let i in value) {
-          stack.push(value[i]);
-        }
-      }
-    }
-    return bytes;
-  }
-
-  _appendLog (logObj) {
-    const heapStats = v8.getHeapStatistics();
-    const heapAvailSize = heapStats.heap_size_limit - heapStats.used_heap_size;
-    const logObjSize = this._objectSize(logObj);
-    if (logObjSize + this.logsSize >= heapAvailSize / 4) {
-      // Shrink log records cache by 25% if its total size is greater than 25% of space
-      // potentially available for allocation by NodeJS heap
-      logger.warn('Shrinking current device logs cache to avoid heap overflow');
-      const shrinkToIdx = this.logs.length / 4;
-      const shrinkSize = this._objectSize(this.logs.slice(0, shrinkToIdx));
-      this.logs = this.logs.slice(shrinkToIdx);
-      this.logsSize -= shrinkSize;
-      if (this.logIdxSinceLastRequest >= 0) {
-        if (this.logIdxSinceLastRequest >= shrinkToIdx) {
-          this.logIdxSinceLastRequest -= shrinkToIdx;
-        } else {
-          this.logIdxSinceLastRequest = 0;
-        }
-      }
-    }
-    this.logs.push(logObj);
-    this.logsSize += logObjSize;
-  }
-
   onOutput (prefix = '') {
     let logs = this.logRow.split('\n');
     for (let log of logs) {
@@ -205,7 +158,10 @@ class IOSLog {
         level: 'ALL',
         message: log
       };
-      this._appendLog(logObj);
+      this.logs.push(logObj);
+      if (this.logs.length > MAX_LOG_ENTRIES_COUNT) {
+        this.logs.shift();
+      }
       if (this.showLogs) {
         let space = prefix.length > 0 ? ' ' : '';
         logger.info(`[IOS_SYSLOG_ROW${space}${prefix}] ${log}`);


### PR DESCRIPTION
It looks like the option with dynamic log size is not working very [well](https://github.com/appium/appium/issues/8083). That is why I decided to make it simple and limit the size by simple constant. 10000 recent log entries should be enough for everyone ;)