### PR TITLE
Add webkitResponseTimeout capability to configure webkit timeout

### DIFF
--- a/lib/commands/context.js
+++ b/lib/commands/context.js
@@ -178,7 +178,10 @@ extensions.listWebFrames = async function (useUrl = true) {
   } else if (this.isRealDevice()) {
     // real device, and not connected
     try {
-      this.remote = new WebKitRemoteDebugger({port: this.opts.webkitDebugProxyPort});
+      this.remote = new WebKitRemoteDebugger({
+        port: this.opts.webkitDebugProxyPort,
+        webkitResponseTimeout: this.opts.webkitResponseTimeout,
+      });
       pageArray = await this.remote.pageArrayFromJson();
     } catch (err) {
       // it is reasonable to expect that this might be called when there is no

--- a/lib/desired-caps.js
+++ b/lib/desired-caps.js
@@ -96,6 +96,9 @@ const desiredCapConstraints = {
   customSSLCert: {
     isString: true
   },
+  webkitResponseTimeout: {
+    isNumber: true
+  },
 };
 
 function desiredCapValidation (caps) {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "appium-base-driver": "^2.0.9",
     "appium-instruments": "^3.9.0",
     "appium-ios-simulator": "^1.10.3",
-    "appium-remote-debugger": "^3.0.0",
+    "appium-remote-debugger": "^3.3.0",
     "appium-support": "^2.4.0",
     "appium-uiauto": "^2.3.2",
     "appium-xcode": "^3.1.0",

--- a/test/e2e/safari/basics-specs.js
+++ b/test/e2e/safari/basics-specs.js
@@ -1,4 +1,4 @@
-import setup from "../setup-base";
+import setup from './safari-setup';
 import env from '../helpers/env';
 import { MOCHA_SAFARI_TIMEOUT } from '../helpers/session';
 
@@ -8,7 +8,10 @@ describe('safari - basics @skip-real-device', function () {
 
   if (!(env.IOS8 || env.IOS9) && env.IOS80) {
     return describe('default init', function () {
-      const driver = setup(this, { browserName: 'safari' }).driver;
+      const driver = setup(this, {
+        browserName: 'safari',
+        noReset: true,
+      }).driver;
 
       it('it should use safari default init page', async () => {
         (await driver.getPageSource()).should.include('Apple');
@@ -17,7 +20,10 @@ describe('safari - basics @skip-real-device', function () {
   }
 
   describe('default init', function () {
-    const driver = setup(this, { browserName: 'safari' }).driver;
+    const driver = setup(this, {
+      browserName: 'safari',
+      noReset: true,
+    }).driver;
 
     it('it should use appium default init page', async () => {
       (await driver.getPageSource()).should.include('Let\'s browse!');
@@ -27,7 +33,8 @@ describe('safari - basics @skip-real-device', function () {
   describe('init with safariInitialUrl', function () {
     const driver = setup(this, {
       browserName: 'safari',
-      safariInitialUrl: env.GUINEA_TEST_END_POINT
+      safariInitialUrl: env.GUINEA_TEST_END_POINT,
+      noReset: true,
     }).driver;
 
     it('should go to the requested page', async () => {

--- a/test/e2e/safari/page-load-timeout-specs.js
+++ b/test/e2e/safari/page-load-timeout-specs.js
@@ -8,7 +8,10 @@ import { MOCHA_SAFARI_TIMEOUT } from '../helpers/session';
 describe.skip('safari - page load timeout', function () {
   this.timeout(MOCHA_SAFARI_TIMEOUT);
 
-  const driver = setup(this, { browserName: 'safari' }).driver;
+  const driver = setup(this, {
+    browserName: 'safari',
+    fullReset: true,
+  }).driver;
 
   describe('small timeout, slow page load', function () {
     it('should not go to the requested page', async () => {

--- a/test/e2e/safari/safari-setup.js
+++ b/test/e2e/safari/safari-setup.js
@@ -1,0 +1,11 @@
+import { default as baseSetup } from '../setup-base';
+
+
+function setup (context, desired, newServer = true) {
+  let session = baseSetup(context, desired, {}, false, newServer);
+
+  return session;
+}
+
+export { setup };
+export default setup;

--- a/test/e2e/safari/touch-specs.js
+++ b/test/e2e/safari/touch-specs.js
@@ -1,4 +1,4 @@
-import setup from "../setup-base";
+import setup from './safari-setup';
 import env from '../helpers/env';
 import B from 'bluebird';
 import { MOCHA_SAFARI_TIMEOUT } from '../helpers/session';
@@ -12,8 +12,6 @@ describe.skip('touch', function () {
 
   const driver = setup(this, {
     browserName: "safari"
-  }, {
-    noReset: true
   }).driver;
 
   it('should flick element', async () => {

--- a/test/e2e/safari/webview/alerts-specs.js
+++ b/test/e2e/safari/webview/alerts-specs.js
@@ -1,5 +1,5 @@
 import desired from './desired';
-import setup from '../../setup-base';
+import setup from '../safari-setup';
 import { loadWebView } from '../../helpers/webview';
 import { MOCHA_SAFARI_TIMEOUT } from '../../helpers/session';
 
@@ -7,7 +7,7 @@ import { MOCHA_SAFARI_TIMEOUT } from '../../helpers/session';
 describe('safari - webview - alerts @skip-real-device', function () {
   this.timeout(MOCHA_SAFARI_TIMEOUT);
 
-  const driver = setup(this, desired, {noReset: true}).driver;
+  const driver = setup(this, desired).driver;
   beforeEach(async () => await loadWebView(desired, driver));
 
   it('should accept alert', async () => {

--- a/test/e2e/safari/webview/basic-specs.js
+++ b/test/e2e/safari/webview/basic-specs.js
@@ -1,6 +1,6 @@
 /* globals expect */
 import desired from './desired';
-import setup from '../../setup-base';
+import setup from '../safari-setup';
 import { loadWebView, spinTitle, spinWait } from '../../helpers/webview';
 import B from 'bluebird';
 import { MOCHA_SAFARI_TIMEOUT } from '../../helpers/session';
@@ -11,7 +11,7 @@ describe('safari - webview ', function () {
   this.timeout(MOCHA_SAFARI_TIMEOUT);
 
   describe('basics', () => {
-    const driver = setup(this, desired, {noReset: true}).driver;
+    const driver = setup(this, desired).driver;
 
     describe('context', function () {
       it('getting current context should work initially', async () => {

--- a/test/e2e/safari/webview/cookies-specs.js
+++ b/test/e2e/safari/webview/cookies-specs.js
@@ -1,5 +1,5 @@
 import desired from './desired';
-import setup from '../../setup-base';
+import setup from '../safari-setup';
 import { loadWebView } from '../../helpers/webview';
 import env from '../../helpers/env';
 import { MOCHA_SAFARI_TIMEOUT } from '../../helpers/session';
@@ -7,7 +7,7 @@ import { MOCHA_SAFARI_TIMEOUT } from '../../helpers/session';
 describe('safari - webview - cookies', function () {
   this.timeout(MOCHA_SAFARI_TIMEOUT);
 
-  const driver = setup(this, desired, {noReset: true}).driver;
+  const driver = setup(this, desired).driver;
 
   describe('within iframe webview', function () {
     it('should be able to get cookies for a page with none', async () => {

--- a/test/e2e/safari/webview/desired.js
+++ b/test/e2e/safari/webview/desired.js
@@ -1,5 +1,5 @@
 export default {
   nativeWebTap: true,
   browserName: 'safari',
-  noReset: true,
+  fullReset: true,
 };

--- a/test/e2e/safari/webview/execute-specs.js
+++ b/test/e2e/safari/webview/execute-specs.js
@@ -1,6 +1,6 @@
 /* globals expect */
 import desired from './desired';
-import setup from '../../setup-base';
+import setup from '../safari-setup';
 import { loadWebView } from '../../helpers/webview';
 import { MOCHA_SAFARI_TIMEOUT } from '../../helpers/session';
 
@@ -13,7 +13,7 @@ const GET_ELEM_BY_TAGNAME = `return document.getElementsByTagName('a');`;
 describe('safari - webview - execute', function () {
   this.timeout(MOCHA_SAFARI_TIMEOUT);
 
-  const driver = setup(this, desired, {noReset: true}, false, true).driver;
+  const driver = setup(this, desired).driver;
   before(async () => await loadWebView(desired, driver));
 
   describe('synchronous', function () {

--- a/test/e2e/safari/webview/frames-specs.js
+++ b/test/e2e/safari/webview/frames-specs.js
@@ -1,5 +1,5 @@
 import desired from './desired';
-import setup from '../../setup-base';
+import setup from '../safari-setup';
 import { loadWebView } from '../../helpers/webview';
 import env from '../../helpers/env';
 import { MOCHA_SAFARI_TIMEOUT } from '../../helpers/session';
@@ -11,7 +11,7 @@ const GET_ELEM_ASYNC = `arguments[arguments.length - 1](document.getElementsByTa
 describe('safari - webview - frames', function () {
   this.timeout(MOCHA_SAFARI_TIMEOUT);
 
-  const driver = setup(this, desired, {noReset: true}, false, true).driver;
+  const driver = setup(this, desired).driver;
 
   describe('frames', function () {
     beforeEach(async () => await loadWebView(

--- a/test/e2e/safari/webview/ssl-specs.js
+++ b/test/e2e/safari/webview/ssl-specs.js
@@ -1,8 +1,9 @@
 import desired from './desired';
 import B from 'bluebird';
 import https from 'https';
-import setup from '../../setup-base';
+import setup from '../safari-setup';
 import { MOCHA_SAFARI_TIMEOUT } from '../../helpers/session';
+
 
 const pem = B.promisifyAll(require('pem'));
 
@@ -10,6 +11,7 @@ describe('When accessing an HTTPS encrypted site in Safari', function () {
   this.timeout(MOCHA_SAFARI_TIMEOUT);
 
   let sslServer;
+  let caps = Object.assign({}, desired);
 
   before(async function () {
     // Create an HTTPS server with a random pem certificate
@@ -20,10 +22,12 @@ describe('When accessing an HTTPS encrypted site in Safari', function () {
     sslServer = https.createServer({key: keys.serviceKey, cert: pemCertificate}, function (req, res) {
       res.end('Arbitrary text');
     }).listen(9758);
-    desired.customSSLCert = pemCertificate;
+    caps.customSSLCert = pemCertificate;
+    caps.fullReset = false;
+    caps.noReset = true;
   });
 
-  const driver = setup(this, desired, {noReset: true}).driver;
+  const driver = setup(this, caps).driver;
 
   after(async () => {
     if (sslServer) {

--- a/test/e2e/safari/windows-frame-specs.js
+++ b/test/e2e/safari/windows-frame-specs.js
@@ -1,4 +1,4 @@
-import setup from "../setup-base";
+import setup from './safari-setup';
 import env from '../helpers/env';
 import { loadWebView, spinTitle } from "../helpers/webview";
 import B from 'bluebird';
@@ -11,7 +11,8 @@ describe(`safari - windows and frames (${env.DEVICE})`, function () {
   const driver = setup(this, {
     browserName: 'safari',
     nativeWebTap: true,
-    safariAllowPopups: true
+    safariAllowPopups: true,
+    fullReset: true,
   }).driver;
 
   describe('within webview', function () {


### PR DESCRIPTION
Add `webkitResponseTimeout` desired capability to set the amount of time (in `ms`) to wait before cancelling a request to the webkit debugger. Operated in conjunction with https://github.com/appium/appium-remote-debugger/pull/57.