### PR TITLE
Use appium-support zip methods instead of adm-zip

### DIFF
--- a/lib/commands/file-movement.js
+++ b/lib/commands/file-movement.js
@@ -1,10 +1,8 @@
 import { errors } from 'appium-base-driver';
-import { fs, system, mkdirp } from 'appium-support';
+import { fs, system, mkdirp, zip } from 'appium-support';
 import logger from '../logger';
 import path from 'path';
 import { exec } from 'teen_process';
-import AdmZip from 'adm-zip';
-import B from 'bluebird';
 
 let commands = {}, helpers = {}, extensions = {};
 
@@ -103,11 +101,7 @@ commands.pullFolder = async function (remotePath) {
   let fullPath = await this.getSimFileFullPath(remotePath);
 
   logger.debug(`Adding ${fullPath} to an in-memory zip archive`);
-  let zip = new AdmZip();
-  zip.addLocalFolder(fullPath);
-  let buffer = await new B((resolve, reject) => {
-    zip.toBuffer(resolve, reject);
-  });
+  let buffer = await zip.toInMemoryZip(fullPath);
 
   logger.debug("Converting in-memory zip file to base64 encoded string");
   let data = buffer.toString('base64');

--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
     "lib": "lib"
   },
   "dependencies": {
-    "adm-zip": "^0.4.7",
     "appium-base-driver": "^2.0.9",
     "appium-instruments": "^3.9.0",
     "appium-ios-simulator": "^1.10.3",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "appium-instruments": "^3.9.0",
     "appium-ios-simulator": "^1.10.3",
     "appium-remote-debugger": "^3.3.0",
-    "appium-support": "^2.4.0",
+    "appium-support": "^2.8.0",
     "appium-xcode": "^3.1.0",
     "asyncbox": "^2.3.1",
     "babel-runtime": "=5.8.24",

--- a/test/unit/file-movement-specs.js
+++ b/test/unit/file-movement-specs.js
@@ -1,0 +1,34 @@
+import { IosDriver } from '../..';
+import sinon from 'sinon';
+import path from 'path';
+import { tempDir, fs, zip } from 'appium-support';
+
+describe('File Movement', () => {
+  let driver;
+  before(() => {
+    driver = new IosDriver();
+  });
+
+  describe('pullFolder()', () => {
+
+    it('should pull a folder from filesystem as a base64 zip, extract the zip and have same contents as in filesystem', async () => {
+      const getSimPathStub = sinon.stub(driver, 'getSimFileFullPath', () => tempPath);
+
+      // Create a temporary directory with one file in it
+      const tempPath = await tempDir.openDir();
+      await fs.writeFile(path.resolve(tempPath, 'a.txt'), 'Hello World!');
+
+      // Zip the directory to base64 and write it to 'zip.zip'
+      const zippedData = await driver.pullFolder('/does/not/matter');
+      const zippedFilepath = path.resolve(tempPath, 'zip.zip');
+      await fs.writeFile(zippedFilepath, zippedData, {encoding: 'base64'});
+
+      // Unzip it and check it matches original file contents
+      const unzippedDir = path.resolve(tempPath, 'unzipped');
+      await zip.extractAllTo(zippedFilepath, unzippedDir);
+      await fs.readFile(path.resolve(unzippedDir, 'a.txt'), {encoding: 'utf8'}).should.eventually.equal('Hello World!');
+
+      getSimPathStub.restore();
+    });
+  });
+});


### PR DESCRIPTION
* `adm-zip` is only used in `commands.pullFolder`
* Added a unit test for `commands.pullFolder`
* Removed `adm-zip` and made the test failed
* Refactored `commands.pullFolder` to use `appium-support` zip methods instead and the tests passed