### PR TITLE
Removed date-utils

### DIFF
--- a/lib/device-log/ios-log.js
+++ b/lib/device-log/ios-log.js
@@ -5,10 +5,6 @@ import { fs, mkdirp } from 'appium-support';
 import xcode from 'appium-xcode';
 import { SubProcess } from 'teen_process';
 
-// Date-Utils: Polyfills for the Date object
-require('date-utils');
-
-
 const START_TIMEOUT = 10000;
 const DEVICE_CONSOLE_PATH = path.resolve(__dirname, '..', '..', '..', 'build', 'deviceconsole');
 const SYSTEM_LOG_PATH = '/var/log/system.log';

--- a/lib/device-log/ios-performance-log.js
+++ b/lib/device-log/ios-performance-log.js
@@ -1,10 +1,6 @@
 import logger from './logger';
 import _ from 'lodash';
 
-
-// Date-Utils: Polyfills for the Date object
-require('date-utils');
-
 const MAX_EVENTS = 5000;
 
 class IOSPerformanceLog {

--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
     "babel-runtime": "=5.8.24",
     "bluebird": "^2.10.2",
     "continuation-local-storage": "^3.1.7",
-    "date-utils": "^1.2.21",
     "js2xmlparser2": "^0.2.0",
     "lodash": "^4.13.1",
     "node-idevice": "^0.1.6",


### PR DESCRIPTION
* Confirmed that the only polyfills used in this repository are `Date.now` and `Date.prototype.toString`
* Tested that these methods are supported in Node v4.x

```
Daniels-MacBook-Pro:appium-ios-driver danielgraham$ node --version
v4.1.2
Daniels-MacBook-Pro:appium-ios-driver danielgraham$ node
> Date.now()
1493073627435
> (new Date()).toString()
'Mon Apr 24 2017 15:40:32 GMT-0700 (PDT)'
```

* Removed date-utils from package.json and removed all `require('date-utils')`

(reviewers @imurchie @jlipps)