### PR TITLE
Allow async exec through https

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@
 
 import yargs from 'yargs';
 import { asyncify } from 'asyncbox';
-import { startServer } from './lib/server';
+import { startServer, startHttpsServer } from './lib/server';
 import { IosDriver, defaultServerCaps } from './lib/driver';
 import { desiredCapConstraints, desiredCapValidation } from './lib/desired-caps';
 import { commands, iosCommands } from './lib/commands/index';
@@ -30,7 +30,7 @@ if (require.main === module) {
 
 export { IosDriver, desiredCapConstraints, desiredCapValidation, commands,
          iosCommands, settings, device, defaultServerCaps, utils, IWDP, uiauto,
-         Instruments, instrumentsUtils };
+         Instruments, instrumentsUtils, startHttpsServer };
 
 export default IosDriver;
 

--- a/lib/commands/execute.js
+++ b/lib/commands/execute.js
@@ -3,6 +3,8 @@ import _ from 'lodash';
 import url from 'url';
 import { util } from 'appium-support';
 import logger from '../logger';
+import { installSSLCert, uninstallSSLCert } from 'appium-ios-simulator';
+import { startHttpsServer } from '../server';
 
 
 let commands = {}, helpers = {}, extensions = {};
@@ -29,7 +31,18 @@ commands.executeAsync = async function (script, args, sessionId) {
   let address = this.opts.callbackAddress || this.opts.address;
   let port = this.opts.callbackPort || this.opts.port;
   sessionId = sessionId || this.sessionId;
-  let responseUrl = `http://${address}:${port}/wd/hub/session/${sessionId}/receive_async_response`;
+
+  // https sites need to reply to an https endpoint, in Safari
+  let protocol = 'http:';
+  try {
+    let currentUrl = url.parse(await this.getUrl());
+    protocol = currentUrl.protocol;
+    if (protocol === 'https:' && this.opts.httpsCallbackPort && this.opts.httpsCallbackAddress) {
+      port = this.opts.httpsCallbackPort;
+      address = this.opts.httpsCallbackAddress;
+    }
+  } catch (ign) {}
+  let responseUrl = `${protocol}//${address}:${port}/wd/hub/session/${sessionId}/receive_async_response`;
 
   if (this.isRealDevice()) {
     let defaultHost = this.opts.address;
@@ -47,6 +60,7 @@ commands.executeAsync = async function (script, args, sessionId) {
 
   logger.debug(`Response url for executeAsync: ${responseUrl}`);
   args = this.convertElementsForAtoms(args);
+  this.asyncWaitMs = this.asyncWaitMs || 0;
   return await this.executeAtomAsync('execute_async_script', [script, args, this.asyncWaitMs], responseUrl);
 };
 
@@ -62,6 +76,34 @@ commands.receiveAsyncResponse = async function (status, value) {
     logger.warn(`Received async response when we were not expecting one! ` +
                 `Response was: ${JSON.stringify(value)}`);
   }
+};
+
+helpers.startHttpsAsyncServer = async function () {
+  logger.debug('Starting https server for async responses');
+  let address = this.opts.callbackAddress || this.opts.address;
+  let port = this.opts.callbackPort || this.opts.port;
+  let {sslServer, pemCertificate, httpsPort} = await startHttpsServer(port, address);
+  this.opts.sslServer = sslServer;
+  this.opts.httpsServerCertificate = pemCertificate;
+  this.opts.httpsCallbackPort = httpsPort;
+  this.opts.httpsCallbackAddress = 'localhost';
+  let udid;
+  if (this.sim) {
+    // ios driver
+    udid = this.sim.udid;
+  } else {
+    // xcuitest driver
+    udid = this.opts.udid;
+  }
+  await installSSLCert(this.opts.httpsServerCertificate, udid);
+};
+
+helpers.stopHttpsAsyncServer = async function () {
+  logger.debug('Stopping https server for async responses');
+  if (this.opts.sslServer) {
+    await this.opts.sslServer.close();
+  }
+  await uninstallSSLCert(this.opts.httpsServerCertificate, this.opts.udid);
 };
 
 commands.executeMobile = async function (mobileCommand, opts={}) {

--- a/lib/desired-caps.js
+++ b/lib/desired-caps.js
@@ -102,6 +102,9 @@ const desiredCapConstraints = {
   enablePerformanceLogging: {
     isBoolean: true
   },
+  enableAsyncExecuteFromHttps: {
+    isBoolean: true
+  },
 };
 
 function desiredCapValidation (caps) {

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -143,7 +143,7 @@ class IosDriver extends BaseDriver {
     this.opts.curOrientation = this.opts.initialOrientation;
 
     this.sock = path.resolve(this.opts.tmpDir || '/tmp', 'instruments_sock');
-    
+
     try {
       await this.configureApp();
     } catch (err) {
@@ -153,6 +153,7 @@ class IosDriver extends BaseDriver {
                    `special app name.`);
       throw err;
     }
+
     await this.start();
 
     // TODO: this should be in BaseDriver.postCreateSession
@@ -178,6 +179,10 @@ class IosDriver extends BaseDriver {
     if (this.caps && this.caps.customSSLCert && !this.isRealDevice()) {
       logger.debug(`Uninstalling ssl certificate for udid '${this.sim.udid}'`);
       await uninstallSSLCert(this.caps.customSSLCert, this.sim.udid);
+    }
+
+    if (this.opts.enableAsyncExecuteFromHttps && !this.isRealDevice()) {
+      await this.stopHttpsAsyncServer();
     }
 
     this.uiAutoClient = null;
@@ -321,11 +326,17 @@ class IosDriver extends BaseDriver {
       }
     }
 
+    await runSimulatorReset(this.sim, this.opts, this.keepAppToRetainPrefs);
+
     if (this.caps.customSSLCert && !this.isRealDevice()) {
       await installSSLCert(this.caps.customSSLCert, this.sim.udid);
     }
 
-    await runSimulatorReset(this.sim, this.opts, this.keepAppToRetainPrefs);
+    if (this.opts.enableAsyncExecuteFromHttps && !this.isRealDevice()) {
+      // await this.sim.shutdown();
+      await this.startHttpsAsyncServer();
+    }
+
     await isolateSimulatorDevice(this.sim, this.opts);
     this.localConfig = await setLocale(this.sim, this.opts, this.localConfig, this.isSafari());
     await setPreferences(this.sim, this.opts, this.isSafari());

--- a/lib/server.js
+++ b/lib/server.js
@@ -1,6 +1,13 @@
 import log from './logger';
 import { server as baseServer, routeConfiguringFunction } from 'appium-base-driver';
 import { IosDriver } from './driver';
+import https from 'https';
+import B from 'bluebird';
+import request from 'request-promise';
+import url from 'url';
+import portfinder from 'portfinder';
+const pem = B.promisifyAll(require('pem'));
+
 
 async function startServer (port, host) {
   let driver = new IosDriver();
@@ -10,4 +17,53 @@ async function startServer (port, host) {
   return server;
 }
 
-export { startServer };
+async function startHttpsServer (port, host) {
+  // Create a random pem certificate
+  let privateKey = await pem.createPrivateKeyAsync();
+  let keys = await pem.createCertificateAsync({days:1, selfSigned: true, serviceKey: privateKey.key});
+  let pemCertificate = keys.certificate;
+
+  // find a port
+  let httpsPort = await portfinder.getPortPromise();
+
+  // Host an SSL server that uses that certificate
+  const serverOpts = {key: keys.serviceKey, cert: pemCertificate};
+  let sslServer = https.createServer(serverOpts, async function (req, res) {
+    log.debug(`Received HTTPS '${req.method}' request for '${req.url}'`);
+    if (req.method === 'OPTIONS') {
+      res.setHeader('Access-Control-Allow-Origin', '*');
+      res.setHeader('Access-Control-Allow-Methods', 'POST, GET, OPTIONS');
+      res.setHeader('Access-Control-Allow-Headers', 'Content-Type');
+      res.writeHead(200);
+      res.end();
+    } else if (req.method === 'POST') {
+      let body = '';
+      req.on('data', function (data) {
+        body += data;
+      });
+      req.on('end', async function () {
+        let httpsUrl = url.parse(req.url);
+        let uri = `http://${host}:${port}${httpsUrl.pathname}`;
+        log.debug(`Passing '${body}' to '${uri}'`);
+
+        // now we send to the right place
+        let options = {
+          method: 'POST',
+          uri,
+          body,
+        };
+        await request(options);
+        res.writeHead(200);
+        res.end();
+      });
+    }
+  }).listen(httpsPort);
+
+  return {
+    sslServer,
+    pemCertificate,
+    httpsPort,
+  };
+}
+
+export { startServer, startHttpsServer };

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "node-idevice": "^0.1.6",
     "node-simctl": "^3.6.0",
     "path": "^0.12.7",
+    "portfinder": "^1.0.13",
     "request": "^2.79.0",
     "request-promise": "^4.1.1",
     "safari-launcher": "^2.0.5",

--- a/test/e2e/safari/webview/execute-specs.js
+++ b/test/e2e/safari/webview/execute-specs.js
@@ -13,68 +13,125 @@ const GET_ELEM_BY_TAGNAME = `return document.getElementsByTagName('a');`;
 describe('safari - webview - execute', function () {
   this.timeout(MOCHA_SAFARI_TIMEOUT);
 
-  const driver = setup(this, desired).driver;
-  before(async () => await loadWebView(desired, driver));
-
-  describe('synchronous', function () {
-    it('should bubble up javascript errors', async () => {
-      await driver.execute(`'nan'--`).should.eventually.be.rejected;
+  describe('http', function () {
+    const driver = setup(this, desired).driver;
+    before(async () => await loadWebView(desired, driver));
+    after(async function () {
+      await driver.deleteSession();
     });
 
-    it('should eval javascript', async () => {
-      (await driver.execute('return 1')).should.be.equal(1);
+    describe('synchronous', function () {
+      it('should bubble up javascript errors', async () => {
+        await driver.execute(`'nan'--`).should.eventually.be.rejected;
+      });
+
+      it('should eval javascript', async () => {
+        (await driver.execute('return 1')).should.be.equal(1);
+      });
+
+      it('should not be returning hardcoded results', async () => {
+        (await driver.execute('return 1+1')).should.be.equal(2);
+      });
+
+      it(`should return nothing when you don't explicitly return`, async () => {
+        expect(await driver.execute('1+1')).to.not.exist;
+      });
+
+      it('should execute code inside the web view', async () => {
+        (await driver.execute(GET_RIGHT_INNERHTML)).should.be.ok;
+        (await driver.execute(GET_WRONG_INNERHTML)).should.not.be.ok;
+      });
+
+      it('should convert selenium element arg to webview element', async () => {
+        let el = await driver.findElement('id', 'useragent');
+        await driver.execute(SCROLL_INTO_VIEW, [el]);
+      });
+
+      it('should catch stale or undefined element as arg', async () => {
+        let el = await driver.findElement('id', 'useragent');
+        return driver.execute(SCROLL_INTO_VIEW, [{'ELEMENT': (el.value + 1)}]).should.beRejected;
+      });
+
+      it('should be able to return multiple elements from javascript', async () => {
+        let res = await driver.execute(GET_ELEM_BY_TAGNAME);
+        expect(res).to.have.length.above(0);
+      });
+      it('should pass along non-element arguments', async () => {
+        let arg = 'non-element-argument';
+        (await driver.execute('var args = Array.prototype.slice.call(arguments, 0); return args[0];', [arg])).should.be.equal(arg);
+      });
+      it('should handle return values correctly', async () => {
+        let arg = ['one', 'two', 'three'];
+        (await driver.execute('var args = Array.prototype.slice.call(arguments, 0); return args;', arg)).should.eql(arg);
+      });
     });
 
-    it('should not be returning hardcoded results', async () => {
-      (await driver.execute('return 1+1')).should.be.equal(2);
-    });
+    describe('asynchronous', function () {
+      it('should bubble up javascript errors', async () => {
+        await driver.execute(`'nan'--`).should.eventually.be.rejected;
+      });
 
-    it(`should return nothing when you don't explicitly return`, async () => {
-      expect(await driver.execute('1+1')).to.not.exist;
-    });
+      it('should execute async javascript', async () => {
+        await driver.asyncScriptTimeout(1000);
+        (await driver.executeAsync(`arguments[arguments.length - 1](123);`)).should.be.equal(123);
+      });
 
-    it('should execute code inside the web view', async () => {
-      (await driver.execute(GET_RIGHT_INNERHTML)).should.be.ok;
-      (await driver.execute(GET_WRONG_INNERHTML)).should.not.be.ok;
-    });
-
-    it('should convert selenium element arg to webview element', async () => {
-      let el = await driver.findElement('id', 'useragent');
-      await driver.execute(SCROLL_INTO_VIEW, [el]);
-    });
-
-    it('should catch stale or undefined element as arg', async () => {
-      let el = await driver.findElement('id', 'useragent');
-      return driver.execute(SCROLL_INTO_VIEW, [{'ELEMENT': (el.value + 1)}]).should.beRejected;
-    });
-
-    it('should be able to return multiple elements from javascript', async () => {
-      let res = await driver.execute(GET_ELEM_BY_TAGNAME);
-      expect(res).to.have.length.above(0);
-    });
-    it('should pass along non-element arguments', async () => {
-      let arg = 'non-element-argument';
-      (await driver.execute('var args = Array.prototype.slice.call(arguments, 0); return args[0];', [arg])).should.be.equal(arg);
-    });
-    it('should handle return values correctly', async () => {
-      let arg = ['one', 'two', 'three'];
-      (await driver.execute('var args = Array.prototype.slice.call(arguments, 0); return args;', arg)).should.eql(arg);
+      it('should timeout when callback is not invoked', async () => {
+        await driver.asyncScriptTimeout(1000);
+        await driver.executeAsync(`return 1 + 2`).should.eventually.be.rejected;
+      });
     });
   });
 
-  describe('asynchronous', function () {
-    it('should bubble up javascript errors', async () => {
-      await driver.execute(`'nan'--`).should.eventually.be.rejected;
+  describe('https', function () {
+    const driver = setup(this, Object.assign({}, desired, {enableAsyncExecuteFromHttps: true})).driver;
+    before(async () => await loadWebView(desired, driver, 'https://www.google.com', 'Google'));
+    after(async function () {
+      await driver.deleteSession();
     });
 
-    it('should execute async javascript', async () => {
-      await driver.asyncScriptTimeout(1000);
-      (await driver.executeAsync(`arguments[arguments.length - 1](123);`)).should.be.equal(123);
+    describe('synchronous', function () {
+      it('should bubble up javascript errors', async () => {
+        await driver.execute(`'nan'--`).should.eventually.be.rejected;
+      });
+
+      it('should eval javascript', async () => {
+        (await driver.execute('return 1')).should.be.equal(1);
+      });
+
+      it('should not be returning hardcoded results', async () => {
+        (await driver.execute('return 1+1')).should.be.equal(2);
+      });
+
+      it(`should return nothing when you don't explicitly return`, async () => {
+        expect(await driver.execute('1+1')).to.not.exist;
+      });
+
+      it('should pass along non-element arguments', async () => {
+        let arg = 'non-element-argument';
+        (await driver.execute('var args = Array.prototype.slice.call(arguments, 0); return args[0];', [arg])).should.be.equal(arg);
+      });
+
+      it('should handle return values correctly', async () => {
+        let arg = ['one', 'two', 'three'];
+        (await driver.execute('var args = Array.prototype.slice.call(arguments, 0); return args;', arg)).should.eql(arg);
+      });
     });
 
-    it('should timeout when callback is not invoked', async () => {
-      await driver.asyncScriptTimeout(1000);
-      await driver.executeAsync(`return 1 + 2`).should.eventually.be.rejected;
+    describe('asynchronous', function () {
+      it('should bubble up javascript errors', async () => {
+        await driver.execute(`'nan'--`).should.eventually.be.rejected;
+      });
+
+      it('should execute async javascript', async () => {
+        await driver.asyncScriptTimeout(1000);
+        (await driver.executeAsync(`arguments[arguments.length - 1](123);`)).should.be.equal(123);
+      });
+
+      it('should timeout when callback is not invoked', async () => {
+        await driver.asyncScriptTimeout(1000);
+        await driver.executeAsync(`return 1 + 2`).should.eventually.be.rejected;
+      });
     });
   });
 });


### PR DESCRIPTION
Add a capability `enableAsyncExecuteFromHttps` to start a HTTPS server that will forward async responses to the normal means. This is required in order to do async executes of JavaScript on pages that are HTTPS.

Only works on simulators, since we need to install a custom SSL cert in order to handle the HTTPS traffic. I will add, when this is all through, some documentation on adding a method to an existing HTTPS server for real device support.