### PR TITLE
Fix import that broke performance logging

### DIFF
--- a/lib/commands/context.js
+++ b/lib/commands/context.js
@@ -2,7 +2,7 @@ import _ from 'lodash';
 import B from 'bluebird';
 import { retryInterval } from 'asyncbox';
 import { RemoteDebugger, WebKitRemoteDebugger } from 'appium-remote-debugger';
-import { IOSPerformanceLog } from '../device-log/ios-performance-log';
+import IOSPerformanceLog from '../device-log/ios-performance-log';
 import { errors } from 'appium-base-driver';
 import logger from '../logger';
 import { util } from 'appium-support';

--- a/lib/device-log/ios-crash-log.js
+++ b/lib/device-log/ios-crash-log.js
@@ -54,4 +54,5 @@ class IOSCrashLog {
   }
 }
 
+export { IOSCrashLog };
 export default IOSCrashLog;

--- a/lib/device-log/ios-log.js
+++ b/lib/device-log/ios-log.js
@@ -186,4 +186,5 @@ class IOSLog {
   }
 }
 
+export { IOSLog };
 export default IOSLog;

--- a/lib/device-log/ios-performance-log.js
+++ b/lib/device-log/ios-performance-log.js
@@ -48,4 +48,6 @@ class IOSPerformanceLog {
   }
 }
 
+
+export { IOSPerformanceLog };
 export default IOSPerformanceLog;


### PR DESCRIPTION
Accidentally importing a named export, but only exporting default.

Fixes https://github.com/appium/appium/issues/8546