### PR TITLE
Do not remove Simulator directory when fullReset is not set

### DIFF
--- a/lib/device.js
+++ b/lib/device.js
@@ -74,7 +74,6 @@ async function resetSimulator (sim, opts, keepApp) {
   logger.debug('Cleaning sim state.');
   try {
     await clearAppData(sim, opts, keepApp);
-    await sim.clean();
   } catch (err) {
     logger.warn(err);
     logger.warn("Could not reset simulator. Leaving as is.");


### PR DESCRIPTION
`resetSimulator` was calling `sim.clean` as `fullResetSimulator` does.