### PR TITLE
Fix Insruments-Without-Delay path

### DIFF
--- a/lib/instruments/utils.js
+++ b/lib/instruments/utils.js
@@ -79,7 +79,7 @@ function parseLaunchTimeout (launchTimeout) {
 }
 
 async function getIwdPath (xcodeMajorVersion) {
-  let thirdpartyPath = path.resolve(rootDir, 'instruments-iwd');
+  let thirdpartyPath = path.resolve(rootDir, '..', 'instruments-iwd');
   let iwdPath = path.resolve(thirdpartyPath, `iwd${xcodeMajorVersion}`);
   if (!await fs.exists(iwdPath)) {
     iwdPath = path.resolve(thirdpartyPath, 'iwd');


### PR DESCRIPTION
`getIwdPath` was always fallbacking to `/build/instruments-iwd/iwd`, which is not even existing since `instruments-iwd` directory is not built.