### PR TITLE
Add realDeviceLogger capability

### DIFF
--- a/lib/commands/logging.js
+++ b/lib/commands/logging.js
@@ -48,8 +48,9 @@ helpers.startLogCapture = async function (sim) {
   this.logs.crashlog = new IOSCrashLog();
   this.logs.syslog = new IOSLog({
     sim,
-    udid: this.opts.udid
-  , showLogs: this.opts.showIOSLog
+    udid: this.opts.udid,
+    showLogs: this.opts.showIOSLog,
+    realDeviceLogger: this.opts.realDeviceLogger,
   });
   try {
     await this.logs.syslog.startCapture();

--- a/lib/desired-caps.js
+++ b/lib/desired-caps.js
@@ -105,6 +105,9 @@ const desiredCapConstraints = {
   enableAsyncExecuteFromHttps: {
     isBoolean: true
   },
+  realDeviceLogger: {
+    isString: true
+  },
 };
 
 function desiredCapValidation (caps) {

--- a/lib/device-log/ios-log.js
+++ b/lib/device-log/ios-log.js
@@ -26,45 +26,73 @@ class IOSLog {
   }
 
   async startCaptureRealDevice () {
+    let cmd, args, env;
     if ((this.realDeviceLogger || '').indexOf('idevicesyslog') !== -1) {
       logger.debug('Attempting iOS device log capture via libimobiledevice idevicesyslog');
-      let idevicesyslog;
-      try {
-        if (this.realDeviceLogger.toLowerCase() === 'idevicesyslog') {
-          idevicesyslog = await fs.which('idevicesyslog');
-        } else {
-          idevicesyslog = this.realDeviceLogger;
+      if (this.realDeviceLogger.toLowerCase() === 'idevicesyslog') {
+        cmd = 'idevicesyslog';
+        try {
+          // make sure it is available on the PATH
+          await fs.which('idevicesyslog');
+        } catch (err) {
+          throw new Error(`Unable to find system idevicesyslog: ${err.message}`);
         }
-        logger.debug(`Using idevicesyslog: '${idevicesyslog}'`);
-
-        this.proc = new SubProcess('idevicesyslog', ['-u', this.udid], {env: process.env});
-      } catch (err) {
-        logger.errorAndThrow(`Unable to capture device log using idevicesyslog: ${err.message}`);
+      } else {
+        // make sure the executable exists
+        if (!await fs.exists(this.realDeviceLogger)) {
+          throw new Error(`Unable to find idevicesyslog from 'realDeviceLogger' capability '${this.realDeviceLogger}'`);
+        }
+        cmd = this.realDeviceLogger;
       }
+
+      args = ['-u', this.udid];
+      env = process.env;
     } else if ((this.realDeviceLogger || '').indexOf('deviceconsole') !== -1) {
       logger.debug('Attempting iOS device log capture via deviceconsole');
       let deviceconsole;
       if (this.realDeviceLogger.toLowerCase() === 'deviceconsole') {
         deviceconsole = DEVICE_CONSOLE_PATH;
       } else {
-        deviceconsole = this.realDeviceLogger;
+        // make sure that we have the path to the directory,
+        // not the actual executable
+        let stat;
+        try {
+          stat = await fs.stat(this.realDeviceLogger);
+        } catch (err) {
+          throw new Error(`Unable to find deviceconsole from 'realDeviceLogger' capability '${this.realDeviceLogger}': ${err.message}`);
+        }
+        if (stat.isDirectory()) {
+          deviceconsole = this.realDeviceLogger;
+        } else {
+          // make sure they've passed in `deviceconsole` and not something random
+          if (this.realDeviceLogger.lastIndexOf('deviceconsole') !== this.realDeviceLogger.length - 'deviceconsole'.length) {
+            throw new Error(`Unable to parse 'deviceconsole' installation directory from '${this.realDeviceLogger}'`);
+          }
+          // remove the executable, and trailing `/`, to get the install directory
+          deviceconsole = this.realDeviceLogger.substring(0, this.realDeviceLogger.length - 'deviceconsole'.length - 1);
+        }
       }
-      logger.debug(`Using default deviceconsole: '${deviceconsole}'`);
 
-      try {
-        // first make sure the executable is actually there
-        await fs.which(path.resolve(deviceconsole, 'deviceconsole'));
+      logger.debug(`Using 'deviceconsole' from '${deviceconsole}'`);
 
-        let spawnEnv = _.clone(process.env);
-        spawnEnv.PATH = `${process.env.PATH}:${deviceconsole}`;
-        spawnEnv.DYLD_LIBRARY_PATH = `${deviceconsole}:${process.env.DYLD_LIBRARY_PATH}`;
-        this.proc = new SubProcess('deviceconsole', ['-u', this.udid], {env: spawnEnv});
-      } catch (err) {
-        logger.errorAndThrow(`Unable to capture device log using deviceconsole: ${err.message}`);
+      cmd = 'deviceconsole';
+      args = ['-u', this.udid];
+
+      // set up the environment to be able to run deviceconsole
+      env = _.clone(process.env);
+      env.PATH = `${deviceconsole}:${process.env.PATH}`;
+      env.DYLD_LIBRARY_PATH = deviceconsole;
+      if (process.env.DYLD_LIBRARY_PATH) {
+        env.DYLD_LIBRARY_PATH = `${env.DYLD_LIBRARY_PATH}:${process.env.DYLD_LIBRARY_PATH}`;
       }
+        // this.proc = new SubProcess('deviceconsole', ['-u', this.udid], {env: spawnEnv});
     } else {
       logger.errorAndThrow(`Unable to capture device log. Unknown 'realDeviceLogger': '${this.realDeviceLogger}'`);
     }
+
+    logger.debug(`Starting iOS device log capture with: '${cmd}'`);
+
+    this.proc = new SubProcess(cmd, args, {env});
 
     await this.finishStartingLogCapture();
   }
@@ -213,5 +241,5 @@ class IOSLog {
   }
 }
 
-export { IOSLog };
+export { IOSLog, DEVICE_CONSOLE_PATH };
 export default IOSLog;

--- a/lib/device-log/ios-log.js
+++ b/lib/device-log/ios-log.js
@@ -16,6 +16,7 @@ class IOSLog {
     this.sim = opts.sim;
     this.udid = opts.udid;
     this.showLogs = !!opts.showLogs;
+    this.realDeviceLogger = opts.realDeviceLogger || 'idevicesyslog';
 
     this.proc = null;
     this.logs = [];
@@ -25,20 +26,46 @@ class IOSLog {
   }
 
   async startCaptureRealDevice () {
-    let spawnEnv = _.clone(process.env);
-    logger.debug('Attempting iOS device log capture via libimobiledevice idevicesyslog');
-    try {
-      let idevicesyslog = await fs.which('idevicesyslog');
-      logger.debug(`Found idevicesyslog: '${idevicesyslog}'`);
-      this.proc = new SubProcess('idevicesyslog', ['-u', this.udid], {env: spawnEnv});
-    } catch (err) {
-      logger.warn('Could not capture device log using libimobiledevice idevicesyslog. ' +
-                  'Libimobiledevice is probably not installed');
+    if ((this.realDeviceLogger || '').indexOf('idevicesyslog') !== -1) {
+      logger.debug('Attempting iOS device log capture via libimobiledevice idevicesyslog');
+      let idevicesyslog;
+      try {
+        if (this.realDeviceLogger.toLowerCase() === 'idevicesyslog') {
+          idevicesyslog = await fs.which('idevicesyslog');
+        } else {
+          idevicesyslog = this.realDeviceLogger;
+        }
+        logger.debug(`Using idevicesyslog: '${idevicesyslog}'`);
+
+        this.proc = new SubProcess('idevicesyslog', ['-u', this.udid], {env: process.env});
+      } catch (err) {
+        logger.errorAndThrow(`Unable to capture device log using idevicesyslog: ${err.message}`);
+      }
+    } else if ((this.realDeviceLogger || '').indexOf('deviceconsole') !== -1) {
       logger.debug('Attempting iOS device log capture via deviceconsole');
-      spawnEnv.PATH = `${process.env.PATH}:${DEVICE_CONSOLE_PATH}`;
-      spawnEnv.DYLD_LIBRARY_PATH = `${DEVICE_CONSOLE_PATH}:${process.env.DYLD_LIBRARY_PATH}`;
-      this.proc = new SubProcess('deviceconsole', ['-u', this.udid], {env: spawnEnv});
+      let deviceconsole;
+      if (this.realDeviceLogger.toLowerCase() === 'deviceconsole') {
+        deviceconsole = DEVICE_CONSOLE_PATH;
+      } else {
+        deviceconsole = this.realDeviceLogger;
+      }
+      logger.debug(`Using default deviceconsole: '${deviceconsole}'`);
+
+      try {
+        // first make sure the executable is actually there
+        await fs.which(path.resolve(deviceconsole, 'deviceconsole'));
+
+        let spawnEnv = _.clone(process.env);
+        spawnEnv.PATH = `${process.env.PATH}:${deviceconsole}`;
+        spawnEnv.DYLD_LIBRARY_PATH = `${deviceconsole}:${process.env.DYLD_LIBRARY_PATH}`;
+        this.proc = new SubProcess('deviceconsole', ['-u', this.udid], {env: spawnEnv});
+      } catch (err) {
+        logger.errorAndThrow(`Unable to capture device log using deviceconsole: ${err.message}`);
+      }
+    } else {
+      logger.errorAndThrow(`Unable to capture device log. Unknown 'realDeviceLogger': '${this.realDeviceLogger}'`);
     }
+
     await this.finishStartingLogCapture();
   }
 

--- a/lib/device-log/ios-log.js
+++ b/lib/device-log/ios-log.js
@@ -65,27 +65,25 @@ class IOSLog {
           deviceconsole = this.realDeviceLogger;
         } else {
           // make sure they've passed in `deviceconsole` and not something random
-          if (this.realDeviceLogger.lastIndexOf('deviceconsole') !== this.realDeviceLogger.length - 'deviceconsole'.length) {
+          if (!_.endsWith(this.realDeviceLogger, 'deviceconsole')) {
             throw new Error(`Unable to parse 'deviceconsole' installation directory from '${this.realDeviceLogger}'`);
           }
           // remove the executable, and trailing `/`, to get the install directory
-          deviceconsole = this.realDeviceLogger.substring(0, this.realDeviceLogger.length - 'deviceconsole'.length - 1);
+          deviceconsole = path.dirname(this.realDeviceLogger);
         }
       }
 
       logger.debug(`Using 'deviceconsole' from '${deviceconsole}'`);
 
-      cmd = 'deviceconsole';
+      cmd = `${deviceconsole}/deviceconsole`;
       args = ['-u', this.udid];
 
       // set up the environment to be able to run deviceconsole
       env = _.clone(process.env);
-      env.PATH = `${deviceconsole}:${process.env.PATH}`;
       env.DYLD_LIBRARY_PATH = deviceconsole;
       if (process.env.DYLD_LIBRARY_PATH) {
         env.DYLD_LIBRARY_PATH = `${env.DYLD_LIBRARY_PATH}:${process.env.DYLD_LIBRARY_PATH}`;
       }
-        // this.proc = new SubProcess('deviceconsole', ['-u', this.udid], {env: spawnEnv});
     } else {
       logger.errorAndThrow(`Unable to capture device log. Unknown 'realDeviceLogger': '${this.realDeviceLogger}'`);
     }

--- a/test/unit/ios-log-specs.js
+++ b/test/unit/ios-log-specs.js
@@ -1,6 +1,7 @@
 // transpile:mocha
 
 import { IOSLog } from '../..';
+import { DEVICE_CONSOLE_PATH } from '../../lib/device-log/ios-log';
 import sinon from 'sinon';
 import { fs } from 'appium-support';
 import path from 'path';
@@ -90,5 +91,109 @@ describe('system logs', () => {
     firstBufferMessage.should.be.equal(logRecordsCount - log.logs.length + 1);
     const lastBufferMessage = parseInt(log.logs[log.logs.length - 1].message, 10);
     lastBufferMessage.should.be.equal(logRecordsCount);
+  });
+
+  describe('real device logging', function () {
+    function getLogger (realDeviceLogger) {
+      let log = new IOSLog({sim, udid: '1234', realDeviceLogger});
+      log.finishStartingLogCapture = async function () {};
+      return log;
+    }
+    describe('idevicesyslog', function () {
+      describe('system version', function () {
+        let whichStub;
+        afterEach(function () {
+          whichStub.restore();
+        });
+
+        it('should use system idevicesyslog if no path specified', async function () {
+          whichStub = sinon.stub(fs, 'which').returns('/path/to/idevicesyslog');
+          let log = getLogger('idevicesyslog');
+          await log.startCapture();
+          log.proc.cmd.should.eql('idevicesyslog');
+        });
+        it('should fail if no system idevicesyslog found', async function () {
+          whichStub = sinon.stub(fs, 'which').throws(new Error('ENOENT'));
+          let log = getLogger('idevicesyslog');
+          await log.startCapture().should.eventually.be.rejectedWith(/Unable to find system idevicesyslog/);
+        });
+      });
+      describe('specific path', function () {
+        let existstub;
+        afterEach(function () {
+          existstub.restore();
+        });
+        it('should use specified idevicesyslog if given', async function () {
+          existstub = sinon.stub(fs, 'exists').returns(true);
+          let log = getLogger('/path/to/my/idevicesyslog');
+          await log.startCapture();
+          log.proc.cmd.should.eql('/path/to/my/idevicesyslog');
+        });
+        it('should fail if specified idevicesyslog is not found', async function () {
+          existstub = sinon.stub(fs, 'exists').returns(false);
+          let log = getLogger('/path/to/my/idevicesyslog');
+          await log.startCapture().should.eventually.be.rejectedWith(/Unable to find idevicesyslog from 'realDeviceLogger' capability/);
+        });
+      });
+    });
+    describe('deviceconsole', function () {
+      let dcPath = '/path/to/deviceconsole/install/directory';
+      let statStub;
+      afterEach(function () {
+        statStub.restore();
+      });
+
+      function initStatStub (directory = true, throws = false) {
+        statStub = sinon.stub(fs, 'stat');
+        if (throws) {
+          statStub.throws(new Error('ENOENT'));
+        } else {
+          statStub.returns({
+            isDirectory () {
+              return directory;
+            }
+          });
+        }
+      }
+
+      it('should correctly parse the install directory from executable path', async function () {
+        initStatStub(false);
+        let log = getLogger(`${dcPath}/deviceconsole`);
+        await log.startCapture();
+        log.proc.cmd.should.eql('deviceconsole');
+        log.proc.opts.env.PATH.indexOf(`${dcPath}:`).should.eql(0);
+      });
+      it('should correctly use the install directory when given directly', async function () {
+        initStatStub();
+        let log = getLogger(dcPath);
+        await log.startCapture();
+        log.proc.cmd.should.eql('deviceconsole');
+        log.proc.opts.env.PATH.indexOf(`${dcPath}:`).should.eql(0);
+      });
+      it('should use default deviceconsole if path not passed in', async function () {
+        initStatStub();
+        let log = getLogger(`deviceconsole`);
+        await log.startCapture();
+        log.proc.cmd.should.eql('deviceconsole');
+        log.proc.opts.env.PATH.indexOf(`${DEVICE_CONSOLE_PATH}:`).should.eql(0);
+      });
+      it('should fail if an executable other than deviceconsole is passed in', async function () {
+        initStatStub(false);
+        let log = getLogger(`${dcPath}/someotherlogger`);
+        await log.startCapture().should.eventually.be.rejectedWith(/Unable to parse 'deviceconsole' installation directory/);
+      });
+      it('should fail if path passed in is not stat-able', async function () {
+        initStatStub(false, true);
+        let log = getLogger(`/path/to/something/that/does/not/exist`);
+        await log.startCapture().should.eventually.be.rejectedWith(/Unknown 'realDeviceLogger'/);
+      });
+    });
+
+    describe('anything else', function () {
+      it('should fail if something other than idevicesyslog or deviceconsole are specified', async function () {
+        let log = getLogger('mysupadupalogga');
+        await log.startCapture().should.eventually.be.rejectedWith(/Unable to capture device log. Unknown 'realDeviceLogger'/);
+      });
+    });
   });
 });

--- a/test/unit/ios-log-specs.js
+++ b/test/unit/ios-log-specs.js
@@ -160,22 +160,22 @@ describe('system logs', () => {
         initStatStub(false);
         let log = getLogger(`${dcPath}/deviceconsole`);
         await log.startCapture();
-        log.proc.cmd.should.eql('deviceconsole');
-        log.proc.opts.env.PATH.indexOf(`${dcPath}:`).should.eql(0);
+        log.proc.cmd.should.eql(`${dcPath}/deviceconsole`);
+        log.proc.opts.env.DYLD_LIBRARY_PATH.indexOf(dcPath).should.eql(0);
       });
       it('should correctly use the install directory when given directly', async function () {
         initStatStub();
         let log = getLogger(dcPath);
         await log.startCapture();
-        log.proc.cmd.should.eql('deviceconsole');
-        log.proc.opts.env.PATH.indexOf(`${dcPath}:`).should.eql(0);
+        log.proc.cmd.should.eql(`${dcPath}/deviceconsole`);
+        log.proc.opts.env.DYLD_LIBRARY_PATH.indexOf(dcPath).should.eql(0);
       });
       it('should use default deviceconsole if path not passed in', async function () {
         initStatStub();
         let log = getLogger(`deviceconsole`);
         await log.startCapture();
-        log.proc.cmd.should.eql('deviceconsole');
-        log.proc.opts.env.PATH.indexOf(`${DEVICE_CONSOLE_PATH}:`).should.eql(0);
+        log.proc.cmd.should.eql(`${DEVICE_CONSOLE_PATH}/deviceconsole`);
+        log.proc.opts.env.DYLD_LIBRARY_PATH.indexOf(DEVICE_CONSOLE_PATH).should.eql(0);
       });
       it('should fail if an executable other than deviceconsole is passed in', async function () {
         initStatStub(false);


### PR DESCRIPTION
Currently we try to use a globally installed `idevicesyslog`, and if that fails we try to use `deviceconsole` which is supposedly installed in Appium's `build` directory. It is not. So that part never works.

Update to allow the user to specify a `realDeviceLogger` capability, which is either:
* nothing (use the system `idevicesyslog`)
* `idevicesyslog` (use the system `idevicesyslog`)
* path to `idevicesyslog`
* `deviceconsole` (use `deviceconsole` in Appium's `build` directory)
* path to `deviceconsole`.

See https://github.com/appium/appium/issues/8698