### PR TITLE
Only change the protocol for https on async execute

### DIFF
--- a/lib/commands/execute.js
+++ b/lib/commands/execute.js
@@ -36,8 +36,8 @@ commands.executeAsync = async function (script, args, sessionId) {
   let protocol = 'http:';
   try {
     let currentUrl = url.parse(await this.getUrl());
-    protocol = currentUrl.protocol;
-    if (protocol === 'https:' && this.opts.httpsCallbackPort && this.opts.httpsCallbackAddress) {
+    if (currentUrl.protocol === 'https:' && this.opts.httpsCallbackPort && this.opts.httpsCallbackAddress) {
+      protocol = currentUrl.protocol;
       port = this.opts.httpsCallbackPort;
       address = this.opts.httpsCallbackAddress;
     }


### PR DESCRIPTION
The only protocols we want to handle are `http:` and `https:`. If it is not the latter, use the former. Ignore things like `file:`.

Resolves https://github.com/appium/appium/issues/8833