### PR TITLE
Add ability to pull tab offset in calculating tap position in safari

### DIFF
--- a/lib/commands/element.js
+++ b/lib/commands/element.js
@@ -10,7 +10,7 @@ commands.getAttribute = async function (attribute, el) {
   if (this.isWebContext()) {
     let atomsElement = this.getAtomsElement(el);
     if (_.isNull(atomsElement)) {
-      throw new errors.UnknownError(`Error converting element ID for using in WD atoms: '${el}`);
+      throw new errors.UnknownError(`Error converting element ID for using in WD atoms: '${el}'`);
     } else {
       return await this.executeAtom('get_attribute_value', [atomsElement, attribute]);
     }

--- a/lib/commands/general.js
+++ b/lib/commands/general.js
@@ -64,17 +64,21 @@ commands.getPageSource = async function () {
     let cmd = 'document.getElementsByTagName("html")[0].outerHTML';
     return await this.remote.execute(cmd);
   } else {
-    let jsonSource = await this.getSourceForElementForXML();
-    if (typeof jsonSource === "string") {
-      jsonSource = JSON.parse(jsonSource);
-    }
-    let xmlSource = js2xml("AppiumAUT", jsonSource, {
-      wrapArray: {enabled: false, elementName: "element"},
-      declaration: {include: true},
-      prettyPrinting: {indentString: "    "}
-    });
-    return xmlSource;
+    return await this.getNativePageSource();
   }
+};
+
+helpers.getNativePageSource = async function () {
+  let jsonSource = await this.getSourceForElementForXML();
+  if (typeof jsonSource === "string") {
+    jsonSource = JSON.parse(jsonSource);
+  }
+  let xmlSource = js2xml("AppiumAUT", jsonSource, {
+    wrapArray: {enabled: false, elementName: "element"},
+    declaration: {include: true},
+    prettyPrinting: {indentString: "    "}
+  });
+  return xmlSource;
 };
 
 commands.background = async function (secs) {

--- a/lib/commands/web.js
+++ b/lib/commands/web.js
@@ -214,7 +214,7 @@ extensions.nativeWebTap = async function (el) {
   let {x, y} = await this.executeAtom('get_top_left_coordinates', [atomsElement]);
   let {width, height} = await this.executeAtom('get_size', [atomsElement]);
   x = x + (width / 2);
-  y = y + (height / 2) + await this.getTabOffset();
+  y = y + (height / 2) + await this.getExtraNativeWebTapOffset();
 
   this.curWebCoords = {x, y};
   await this.clickWebCoords();
@@ -222,7 +222,7 @@ extensions.nativeWebTap = async function (el) {
   await B.delay(500);
 };
 
-extensions.getTabOffset = async function () {
+extensions.getExtraNativeWebTapOffset = async function () {
   // this will be filled in by drivers using it
   return 0;
 };
@@ -379,7 +379,7 @@ helpers.useAtomsElement = function (el) {
   }
   let atomsElement = this.getAtomsElement(el);
   if (atomsElement === null) {
-    throw new errors.UnknownError(`Error converting element ID for using in WD atoms: ${el}`);
+    throw new errors.UnknownError(`Error converting element ID for using in WD atoms: '${el}'`);
   }
   return atomsElement;
 };
@@ -390,7 +390,7 @@ helpers.convertElementsForAtoms = function (args = []) {
     if (!_.isNull(arg) && !_.isUndefined(arg.ELEMENT)) {
       let atomsElement = this.getAtomsElement(arg.ELEMENT);
       if (atomsElement === null) {
-        throw new errors.UnknownError(`Error converting element ID for using in WD atoms: ${arg.ELEMENT}`);
+        throw new errors.UnknownError(`Error converting element ID for using in WD atoms: '${arg.ELEMENT}'`);
       }
       newArgs.push(atomsElement);
     } else {
@@ -408,7 +408,7 @@ helpers.parseExecuteResponse = function (res) {
     if (!_.isUndefined(res.ELEMENT)) {
       wdElement = this.parseElementResponse(res);
       if (wdElement === null) {
-        throw new errors.UnknownError(`Error converting element ID atom for using in WD: ${res.ELEMENT}`);
+        throw new errors.UnknownError(`Error converting element ID atom for using in WD: '${res.ELEMENT}'`);
       }
       res = wdElement;
     }
@@ -420,7 +420,7 @@ helpers.parseExecuteResponse = function (res) {
       if (!_.isNull(arg) && !_.isUndefined(arg.ELEMENT)) {
         wdElement = this.parseElementResponse(arg);
         if (wdElement === null) {
-          throw new errors.UnknownError(`Error converting element ID atom for using in WD: ${arg.ELEMENT}`);
+          throw new errors.UnknownError(`Error converting element ID atom for using in WD: '${arg.ELEMENT}'`);
         }
         args.push(wdElement);
       } else {

--- a/lib/commands/web.js
+++ b/lib/commands/web.js
@@ -208,16 +208,23 @@ extensions.mobileWebNav = async function (navType) {
   await this.executeAtom('execute_script', [`history.${navType}();`, null]);
 };
 
+
 extensions.nativeWebTap = async function (el) {
   let atomsElement = this.useAtomsElement(el);
   let {x, y} = await this.executeAtom('get_top_left_coordinates', [atomsElement]);
   let {width, height} = await this.executeAtom('get_size', [atomsElement]);
   x = x + (width / 2);
-  y = y + (height / 2);
+  y = y + (height / 2) + await this.getTabOffset();
+
   this.curWebCoords = {x, y};
   await this.clickWebCoords();
   // make sure real tap actually has time to register
   await B.delay(500);
+};
+
+extensions.getTabOffset = async function () {
+  // this will be filled in by drivers using it
+  return 0;
 };
 
 extensions.clickWebCoords = async function () {


### PR DESCRIPTION
Add `getTabOffset` method to get the amount of space used by tabs in iPad Safari tests. This will be used in xcuitest-driver in order to add the right amount of space.