### PR TITLE
Add fullContextList cap to return context list with url and title

### DIFF
--- a/lib/commands/context.js
+++ b/lib/commands/context.js
@@ -25,7 +25,19 @@ commands.getCurrentContext = async function () {
 commands.getContexts = async function () {
   logger.debug('Getting list of available contexts');
   let contexts = await this.getContextsAndViews(false);
-  return contexts.map((context) => context.id.toString());
+
+
+  let mapFn = (context) => context.id.toString();
+  if (this.opts.fullContextList) {
+    mapFn = (context) => {
+      return {
+        id: context.id.toString(),
+        title: context.view.title,
+        url: context.view.url,
+      };
+    };
+  }
+  return contexts.map(mapFn);
 };
 
 commands.setContext = async function (name, callback, skipReadyCheck) {
@@ -148,7 +160,7 @@ extensions.initAutoWebview = async function () {
 extensions.getContextsAndViews = async function (useUrl = true) {
   logger.debug('Retrieving contexts and views');
   let webviews = await this.listWebFrames(useUrl);
-  let ctxs = [{id: NATIVE_WIN}];
+  let ctxs = [{id: NATIVE_WIN, view: {}}];
   this.contexts = [NATIVE_WIN];
   for (let view of webviews) {
     ctxs.push({id: `${WEBVIEW_BASE}${view.id}`, view});
@@ -200,6 +212,7 @@ extensions.listWebFrames = async function (useUrl = true) {
       pageLoadMs: this.pageLoadMs,
       platformVersion: this.opts.platformVersion
     });
+
 
     let appInfo = await this.remote.connect();
     if (!appInfo) {

--- a/lib/desired-caps.js
+++ b/lib/desired-caps.js
@@ -108,6 +108,9 @@ const desiredCapConstraints = {
   realDeviceLogger: {
     isString: true
   },
+  fullContextList: {
+    isBoolean: true
+  },
 };
 
 function desiredCapValidation (caps) {


### PR DESCRIPTION
Sometimes it is necessary to know more about the contexts available than just the id, which we currently return.

So, behind a capability `fullContextList`, this PR adds the url and title to the returned list. If this is amendable, I will open a PR to add this to the mobile spec.

Current information returned:
```
[ 'NATIVE_APP', 'WEBVIEW_65515.1' ]
```

With the `fullContextList` capability and this PR:
```
[ { 
    id: 'NATIVE_APP' 
  },
  { 
    id: 'WEBVIEW_69623.1',
    title: 'I am a page title',
    url: 'http://localhost:4994/test/guinea-pig' 
  }
 ]
```

This way if there are multiple webviews the appropriate one can be chosen by the client, rather than needing to cycle through them and query the page to find the correct one.