### PR TITLE
Remove legacy stuff from logs handler and update it for proper Xcode9 support

### DIFF
--- a/lib/device-log/ios-log.js
+++ b/lib/device-log/ios-log.js
@@ -1,13 +1,12 @@
 import path from 'path';
 import _ from 'lodash';
 import logger from './logger';
-import { fs, mkdirp } from 'appium-support';
+import { fs } from 'appium-support';
 import xcode from 'appium-xcode';
-import { SubProcess } from 'teen_process';
+import { SubProcess, exec } from 'teen_process';
 
 const START_TIMEOUT = 10000;
 const DEVICE_CONSOLE_PATH = path.resolve(__dirname, '..', '..', '..', 'build', 'deviceconsole');
-const SYSTEM_LOG_PATH = '/var/log/system.log';
 // We keep only the most recent log entries to avoid out of memory error
 const MAX_LOG_ENTRIES_COUNT = 10000;
 
@@ -90,6 +89,10 @@ class IOSLog {
 
     logger.debug(`Starting iOS device log capture with: '${cmd}'`);
 
+    try {
+      // cleanup existing listeners if the previous session has not been terminated properly
+      await exec('pkill', ['-xf', [cmd, ...args].join(' ')]);
+    } catch (e) {}
     this.proc = new SubProcess(cmd, args, {env});
 
     await this.finishStartingLogCapture();
@@ -103,49 +106,31 @@ class IOSLog {
     let xCodeVersion = await xcode.getVersion(true);
 
     logger.debug(`Starting iOS ${await this.sim.getPlatformVersion()} simulator log capture`);
-    if (xCodeVersion.major < 5) {
-      this.proc = new SubProcess('tail', ['-f', '-n', '1', SYSTEM_LOG_PATH]);
-      await this.finishStartingLogCapture();
-      return;
-    }
 
-    // this is xcode 6+
     if (_.isUndefined(this.sim.udid)) {
       logger.errorAndThrow(`iOS ${xCodeVersion.versionString} log capture requires a sim udid`);
     }
 
-    let logPath = this.sim.getLogDir();
+    const logsRoot = this.sim.getLogDir();
     try {
-      if (logPath.indexOf('*') >= 0) {
-        logger.error(`Log path has * in it. Unable to start log capture: ${logPath}`);
+      if (logsRoot.indexOf('*') >= 0) {
+        logger.error(`Log path has * in it. Unable to start log capture: ${logsRoot}`);
         return;
       }
-      let systemLogPath = path.resolve(logPath, 'system.log');
+      let systemLogPath = path.resolve(logsRoot, 'system.log');
+      if (!await fs.exists(systemLogPath)) {
+        throw new Error(`Could not start log capture because no iOS ` +
+          `simulator logs could be found at ${systemLogPath}. ` +
+          `Logging will not be functional for this run`);
+      }
       logger.debug(`System log path: ${systemLogPath}`);
-      await mkdirp(logPath);
-      await fs.writeFile(systemLogPath, 'A new Appium session is about to start!\n', {flag: 'a'});
-      let files;
-      try {
-        files = await fs.glob(systemLogPath);
-        if (files.length < 1) {
-          throw new Error('Could not start log capture');
-        }
-      } catch (e) {
-        logger.error(`Could not start log capture because no iOS ` +
-                     `simulator logs could be found at ${systemLogPath}. ` +
-                     `Logging will not be functional for this run`);
-      }
 
-      let lastModifiedLogPath = files[0];
-      let lastModifiedLogTime = await fs.stat(lastModifiedLogPath).mtime;
-      for (let file of files) {
-        let mtime = await fs.stat(file).mtime;
-        if (mtime > lastModifiedLogTime) {
-          lastModifiedLogPath = file;
-          lastModifiedLogTime = mtime;
-        }
-      }
-      this.proc = new SubProcess('tail', ['-f', '-n', '1', lastModifiedLogPath]);
+      const tailArgs = ['-f', '-n', '1', systemLogPath];
+      try {
+        // cleanup existing listeners if the previous session has not been terminated properly
+        await exec('pkill', ['-xf', ['tail', ...tailArgs].join(' ')]);
+      } catch (e) {}
+      this.proc = new SubProcess('tail', tailArgs);
       await this.finishStartingLogCapture();
     } catch (err) {
       logger.errorAndThrow(`System log capture failed: ${err.message}`);


### PR DESCRIPTION
It looks like Xcode9 Simulator does not really like if we append anything to the system logs ourselves (it just stops logging at all). Also, the logic there contains some obsolete stuff for Xcode 6 and older, which we don't support anymore.