### PR TITLE
Make sure we return something useful from getting the date

### DIFF
--- a/lib/commands/general.js
+++ b/lib/commands/general.js
@@ -27,7 +27,11 @@ commands.getDeviceTime = async function () {
       stdout = stdout.trim();
       try {
         let date = new Date(stdout);
-        return date.toString();
+        let dateStr = date.toString();
+        if (dateStr === 'Invalid Date') {
+          throw new Error('Unable to parse idevicedate output');
+        }
+        return dateStr;
       } catch (err) {
         // sometimes `idevicedate` returns an un-parsable format
         // in which case, we just want to return the output and

--- a/test/unit/driver-specs.js
+++ b/test/unit/driver-specs.js
@@ -87,59 +87,74 @@ describe('driver', () => {
 });
 
 describe('getDeviceTime', withMocks({fs, teen_process}, (mocks) => {
-  it('should call idevicedate on real device', async () => {
-    let udid = 'some-udid';
-    let date = new Date().toString();
-    let idevicedatePath = '/path/to/idevicedate';
-    mocks.fs.expects('which')
-      .once().returns(idevicedatePath);
-    mocks.teen_process.expects('exec')
-      .once().withExactArgs(idevicedatePath, ['-u', udid])
-      .returns({stdout: date});
-    let driver = new IosDriver();
-    driver.opts = {udid};
+  describe('real device', function () {
+    const setup = function (mocks, opts = {}) {
+      let udid = 'some-udid';
+      let idevicedatePath = '/path/to/idevicedate';
+      mocks.fs.expects('which')
+        .once().returns(idevicedatePath);
+      if (opts.date) {
+        mocks.teen_process.expects('exec')
+          .once().withExactArgs(idevicedatePath, ['-u', udid])
+          .returns({stdout: opts.date});
+      } else {
+        mocks.teen_process.expects('exec')
+          .once().withExactArgs(idevicedatePath, ['-u', udid])
+          .throws('ENOENT');
+      }
+      let driver = new IosDriver();
+      driver.opts = {udid};
 
-    (await driver.getDeviceTime()).should.equal(date);
+      return driver;
+    };
 
-    mocks.fs.verify();
-    mocks.teen_process.verify();
+    it('should call idevicedate', async () => {
+      let date = new Date().toString();
+      let driver = setup(mocks, {date});
+      (await driver.getDeviceTime()).should.equal(date);
+
+      mocks.fs.verify();
+      mocks.teen_process.verify();
+    });
+
+    it('should return output of idevicedate if unparseable', async () => {
+      let date = 'some time and date';
+      let driver = setup(mocks, {date});
+      (await driver.getDeviceTime()).should.equal(date);
+
+      mocks.fs.verify();
+      mocks.teen_process.verify();
+    });
+
+    it('should throw an error when idevicedate cannot be found', async () => {
+      mocks.fs.expects('which')
+        .once().throws();
+      let driver = new IosDriver();
+      driver.opts = {udid: 'some-udid'};
+      await driver.getDeviceTime()
+        .should.eventually.be.rejectedWith('Could not capture device date and time');
+
+      mocks.fs.verify();
+    });
+
+    it('should throw an error when idevicedate fails', async () => {
+      let driver = setup(mocks);
+      await driver.getDeviceTime()
+        .should.eventually.be.rejectedWith("Could not capture device date and time");
+
+      mocks.fs.verify();
+      mocks.teen_process.verify();
+    });
   });
 
-  it('should throw an error when idevicedate cannot be found', async () => {
-    let udid = 'some-udid';
-    mocks.fs.expects('which')
-      .once().throws();
-    let driver = new IosDriver();
-    driver.opts = {udid};
-    await driver.getDeviceTime()
-      .should.eventually.be.rejectedWith("Could not capture device date and time");
+  describe('simulator', function () {
+    it('should return system date', async () => {
+      mocks.teen_process.expects('exec')
+        .never();
+      let driver = new IosDriver();
+      (await driver.getDeviceTime()).should.be.an instanceof(String);
 
-    mocks.fs.verify();
-  });
-
-  it('should throw an error when idevicedate fails', async () => {
-    let udid = 'some-udid';
-    let idevicedatePath = '/path/to/idevicedate';
-    mocks.fs.expects('which')
-      .once().returns(idevicedatePath);
-    mocks.teen_process.expects("exec")
-      .once().withExactArgs(idevicedatePath, ['-u', udid])
-      .throws("ENOENT");
-    let driver = new IosDriver();
-    driver.opts = {udid};
-    await driver.getDeviceTime()
-      .should.eventually.be.rejectedWith("Could not capture device date and time");
-
-    mocks.fs.verify();
-    mocks.teen_process.verify();
-  });
-
-  it('should return system date on simulator', async () => {
-    mocks.teen_process.expects("exec")
-      .never();
-    let driver = new IosDriver();
-    (await driver.getDeviceTime()).should.be.an instanceof(String);
-
-    mocks.teen_process.verify();
+      mocks.teen_process.verify();
+    });
   });
 }));


### PR DESCRIPTION
If we can't parse the date string from `idevicedate`, return something useful (i.e., the output itself).

See https://github.com/appium/appium/issues/7835