### PR TITLE
Fix access to await result

### DIFF
--- a/lib/device-log/ios-log.js
+++ b/lib/device-log/ios-log.js
@@ -138,9 +138,9 @@ class IOSLog {
       }
 
       let lastModifiedLogPath = files[0];
-      let lastModifiedLogTime = await fs.stat(lastModifiedLogPath).mtime;
+      let lastModifiedLogTime = (await fs.stat(lastModifiedLogPath)).mtime;
       for (let file of files) {
-        let mtime = await fs.stat(file).mtime;
+        let {mtime} = await fs.stat(file);
         if (mtime > lastModifiedLogTime) {
           lastModifiedLogPath = file;
           lastModifiedLogTime = mtime;


### PR DESCRIPTION
`fs.stat(lastModifiedLogPath)` returns a Promise, so we need to apply `await` before accessing the `mtime` property, but not after it. Currently the code tries to get `mtime` from the promise instance, which results in `undefined` and then applies `await` to `undefined`, which results in the same output.