### PR TITLE
Pass in xcode version to ios logger, rather than computing again

### DIFF
--- a/lib/commands/logging.js
+++ b/lib/commands/logging.js
@@ -56,6 +56,7 @@ helpers.startLogCapture = async function (sim) {
     udid: this.opts.udid,
     showLogs: this.opts.showIOSLog,
     realDeviceLogger: this.opts.realDeviceLogger,
+    xcodeVersion: this.xcodeVersion,
   });
   try {
     await this.logs.syslog.startCapture();

--- a/lib/device-log/ios-log.js
+++ b/lib/device-log/ios-log.js
@@ -2,7 +2,6 @@ import path from 'path';
 import _ from 'lodash';
 import logger from './logger';
 import { fs, mkdirp } from 'appium-support';
-import xcode from 'appium-xcode';
 import { SubProcess, exec } from 'teen_process';
 
 const START_TIMEOUT = 10000;
@@ -17,6 +16,7 @@ class IOSLog {
     this.udid = opts.udid;
     this.showLogs = !!opts.showLogs;
     this.realDeviceLogger = opts.realDeviceLogger || 'idevicesyslog';
+    this.xcodeVersion = opts.xcodeVersion;
 
     this.proc = null;
     this.logs = [];
@@ -100,11 +100,9 @@ class IOSLog {
   }
 
   async startCaptureSimulator () {
-     // otherwise, if we have a simulator...
-    let xCodeVersion = await xcode.getVersion(true);
-
+    // otherwise, if we have a simulator...
     logger.debug(`Starting iOS ${await this.sim.getPlatformVersion()} simulator log capture`);
-    if (xCodeVersion.major < 5) {
+    if (this.xcodeVersion.major < 5) {
       this.proc = new SubProcess('tail', ['-f', '-n', '1', SYSTEM_LOG_PATH]);
       await this.finishStartingLogCapture();
       return;
@@ -112,7 +110,7 @@ class IOSLog {
 
     // this is xcode 6+
     if (_.isUndefined(this.sim.udid)) {
-      logger.errorAndThrow(`iOS ${xCodeVersion.versionString} log capture requires a sim udid`);
+      logger.errorAndThrow(`iOS log capture with Xcode ${this.xcodeVersion.versionString} requires a sim udid`);
     }
 
     let logPath = this.sim.getLogDir();

--- a/test/unit/ios-log-specs.js
+++ b/test/unit/ios-log-specs.js
@@ -41,7 +41,13 @@ describe('system logs', function () {
   });
 
   it('should begin log capture', async function () {
-    let log = new IOSLog({sim, showLogs: true});
+    let log = new IOSLog({
+      sim,
+      showLogs: true,
+      xcodeVersion: {
+        major: 7
+      },
+    });
     let spy = sinon.spy(logger, 'info');
 
     await log.startCapture();
@@ -64,7 +70,13 @@ describe('system logs', function () {
     const logRecordsCount = maxBufferSize * 2;
     logRecordsCount.should.be.above(maxBufferSize);
 
-    let log = new IOSLog({sim, showLogs: false});
+    let log = new IOSLog({
+      sim,
+      showLogs: false,
+      xcodeVersion: {
+        major: 7
+      },
+    });
     log.maxBufferSize = maxBufferSize;
     log.logIdxSinceLastRequest.should.be.below(0);
     let recentLogs = await log.getLogs();


### PR DESCRIPTION
We already have the xcode version at the point we instantiate the logger, so just pass it in, since this is not a trivial operation.

Related (tangentially) to the work of https://github.com/appium/appium/issues/10188