### PR TITLE
Abstract out remote debugger creation

### DIFF
--- a/lib/commands/context.js
+++ b/lib/commands/context.js
@@ -169,6 +169,15 @@ extensions.getContextsAndViews = async function (useUrl = true) {
   return ctxs;
 };
 
+extensions.getNewRemoteDebugger = async function () {
+  return new RemoteDebugger({
+    bundleId: this.opts.bundleId,
+    useNewSafari: this.useNewSafari(),
+    pageLoadMs: this.pageLoadMs,
+    platformVersion: this.opts.platformVersion
+  });
+};
+
 extensions.listWebFrames = async function (useUrl = true) {
   if (!this.opts.bundleId) {
     logger.errorAndThrow('Cannot enter web frame without a bundle ID');
@@ -206,13 +215,7 @@ extensions.listWebFrames = async function (useUrl = true) {
     }
   } else {
     // simulator, and not connected
-    this.remote = new RemoteDebugger({
-      bundleId: this.opts.bundleId,
-      useNewSafari: this.useNewSafari(),
-      pageLoadMs: this.pageLoadMs,
-      platformVersion: this.opts.platformVersion
-    });
-
+    this.remote = await this.getNewRemoteDebugger();
 
     let appInfo = await this.remote.connect();
     if (!appInfo) {


### PR DESCRIPTION
So subclasses can instantiate it differently. The function is `async` so subclasses can do async-y things, even if it is not necessary here.