### PR TITLE
Update get device time algorithm

### DIFF
--- a/lib/commands/general.js
+++ b/lib/commands/general.js
@@ -6,8 +6,11 @@ import { fs, util } from 'appium-support';
 import { exec } from 'teen_process';
 import utils from '../utils';
 import { openUrl } from 'node-simctl';
+import moment from 'moment';
 
 let commands = {}, helpers = {}, extensions = {};
+
+const MOMENT_FORMAT_ISO8601 = 'YYYY-MM-DDTHH:mm:ssZ';
 
 commands.active = async function () {
   if (this.isWebContext()) {
@@ -17,36 +20,45 @@ commands.active = async function () {
   }
 };
 
-commands.getDeviceTime = async function () {
+/**
+ * Retrieves the current device's timestamp.
+ *
+ * @param {string} format - The set of format specifiers. Read
+ *                          https://momentjs.com/docs/ to get the full list of supported
+ *                          datetime format specifiers. The default format is
+ *                          `YYYY-MM-DDTHH:mm:ssZ`, which complies to ISO-8601
+ * @returns Formatted datetime string or the raw command output if formatting fails
+ */
+commands.getDeviceTime = async function (format = MOMENT_FORMAT_ISO8601) {
   log.info('Attempting to capture iOS device date and time');
+  let cmd;
+  let args;
+  let inputFormat;
   if (this.isRealDevice()) {
     try {
-      let idevicedate = await fs.which('idevicedate');
-      log.info(`Found idevicedate: '${idevicedate}'`);
-      let {stdout} = await exec(idevicedate, ['-u', this.opts.udid]);
-      stdout = stdout.trim();
-      try {
-        let date = new Date(stdout);
-        let dateStr = date.toString();
-        if (dateStr === 'Invalid Date') {
-          throw new Error('Unable to parse idevicedate output');
-        }
-        return dateStr;
-      } catch (err) {
-        // sometimes `idevicedate` returns an un-parsable format
-        // in which case, we just want to return the output and
-        // let the client deal with it
-        log.debug(`Unable to parse date '${stdout}'. Returning as is`);
-        return stdout;
-      }
+      cmd = await fs.which('idevicedate');
     } catch (err) {
       log.errorAndThrow('Could not capture device date and time using libimobiledevice idevicedate. ' +
-                     'Libimobiledevice is probably not installed');
+                        'Libimobiledevice is probably not installed');
     }
+    log.info(`Found idevicedate: '${cmd}'`);
+    // https://github.com/libimobiledevice/libimobiledevice/blob/26373b334889f5ae2e2737ff447eb25b1700fa2f/tools/idevicedate.c#L129
+    args = ['-u', this.opts.udid];
+    inputFormat = 'ddd MMM DD HH:mm:ss z YYYY';
   } else {
     log.warn('On simulator. Assuming device time is the same as host time');
-    return new Date().toString();
+    cmd = 'date';
+    args = ['+%Y-%m-%dT%H:%M:%S%z'];
+    inputFormat = MOMENT_FORMAT_ISO8601;
   }
+  const stdout = (await exec(cmd, args)).stdout.trim();
+  log.debug(`Got the following output out of '${cmd} ${args.join(' ')}': ${stdout}`);
+  const parsedTimestamp = moment(stdout, inputFormat);
+  if (!parsedTimestamp.isValid()) {
+    log.warn(`Cannot parse the timestamp '${stdout}' returned by '${cmd}' command. Returning it as is`);
+    return stdout;
+  }
+  return parsedTimestamp.format(format);
 };
 
 commands.hideKeyboard = async function (strategy, ...possibleKeys) {

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "continuation-local-storage": "^3.1.7",
     "js2xmlparser2": "^0.2.0",
     "lodash": "^4.13.1",
+    "moment": "^2.22.2",
     "node-idevice": "^0.1.6",
     "node-simctl": "^3.11.5",
     "path": "^0.12.7",

--- a/test/unit/driver-specs.js
+++ b/test/unit/driver-specs.js
@@ -142,9 +142,15 @@ describe('getDeviceTime', withMocks({fs, teen_process}, (mocks) => {
     };
 
     it('should call idevicedate', async function () {
-      let date = new Date().toString();
+      let date = 'Tue Jun 12 11:13:31 CEST 2018';
       let driver = setup(mocks, {date});
-      (await driver.getDeviceTime()).should.equal(date);
+      (await driver.getDeviceTime()).startsWith('2018-06-12T').should.be.true;
+    });
+
+    it('should call idevicedate with format', async function () {
+      let date = 'Tue Jun 12 11:13:31 CEST 2018';
+      let driver = setup(mocks, {date});
+      (await driver.getDeviceTime('YYYY-MM-DD')).should.equal('2018-06-12');
     });
 
     it('should return output of idevicedate if unparseable', async function () {
@@ -161,20 +167,15 @@ describe('getDeviceTime', withMocks({fs, teen_process}, (mocks) => {
       await driver.getDeviceTime()
         .should.eventually.be.rejectedWith('Could not capture device date and time');
     });
-
-    it('should throw an error when idevicedate fails', async function () {
-      let driver = setup(mocks);
-      await driver.getDeviceTime()
-        .should.eventually.be.rejectedWith("Could not capture device date and time");
-    });
   });
 
   describe('simulator', function () {
     it('should return system date', async function () {
       mocks.teen_process.expects('exec')
-        .never();
+        .once().withExactArgs('date', ['+%Y-%m-%dT%H:%M:%S%z'])
+        .returns({stdout: '2018-06-12T12:11:59+0200'});
       let driver = new IosDriver();
-      (await driver.getDeviceTime()).should.be.an instanceof(String);
+      (await driver.getDeviceTime()).startsWith('2018-06-12T').should.be.true;
     });
   });
 }));


### PR DESCRIPTION
It might be handy to sync this functionality on both Android and iOS. I'm going to create one more PR for Android, because `date`-specific time format specifiers are not very universal accross different platforms and it might be more handy to use these which are supported by moment.js library, since they are cross-platform.

@KazuCocoa FYI