### PR TITLE
Handle dead idevicesyslog on closing

### DIFF
--- a/lib/device-log/ios-log.js
+++ b/lib/device-log/ios-log.js
@@ -210,10 +210,12 @@ class IOSLog extends EventEmitter {
       if (this.udid) {
         // If no other UDID's are using 'idevicesyslog' kill it
         const cachedSysLog = IOSLog.cachedIDeviceSysLogs[this.subprocessId];
-        cachedSysLog.count--;
-        if (cachedSysLog.count === 0) {
-          await this.killLogSubProcess();
-          delete IOSLog.cachedIDeviceSysLogs[this.subprocessId];
+        if (cachedSysLog) {
+          cachedSysLog.count--;
+          if (cachedSysLog.count === 0) {
+            await this.killLogSubProcess();
+            delete IOSLog.cachedIDeviceSysLogs[this.subprocessId];
+          }
         }
       } else {
         await this.killLogSubProcess();


### PR DESCRIPTION
If the `idevicesyslog` process dies, it is removed from the hash, so we need to check if the returned element exists before messing with it.

Should fix https://github.com/appium/appium/issues/11048