### PR TITLE
Clear frames when a new page loads.

### DIFF
--- a/lib/commands/context.js
+++ b/lib/commands/context.js
@@ -330,6 +330,9 @@ extensions.onPageChange = async function (pageChangeNotification) {
         await this.remote.pageLoad();
       }
 
+      logger.debug("Clearing any frames");
+      this.curWebFrames = [];
+
       logger.debug('New page listing is same as old, doing nothing');
     }
   }


### PR DESCRIPTION
- Otherwise we still try to run atoms in the frame, which fails.
- Should fix appium/appium#11102.