### PR TITLE
Fix for new timeout logic

### DIFF
--- a/test/e2e/testapp/timeout/implicit-wait-specs.js
+++ b/test/e2e/testapp/timeout/implicit-wait-specs.js
@@ -3,7 +3,7 @@ import desired from '../desired';
 import env from '../../helpers/env';
 import B from 'bluebird';
 import { throwMatchableError } from '../../helpers/recipes';
-import {BaseDriver} from "appium-base-driver";
+
 
 describe('testapp - timeout', function () {
   this.timeout(env.MOCHA_INIT_TIMEOUT);
@@ -41,13 +41,13 @@ describe('testapp - timeout', function () {
     });
 
     it('should work with small command timeout', async function () {
-      await driver.timeouts({protocol: BaseDriver.DRIVER_PROTOCOL.MJSONWP, type: 'command', ms: 5000}, "1dcfe021-8fc8-49bd-8dac-e986d3091b97");
+      await driver.timeouts('command', 5000);
       await driver.implicitWait(10000);
       await impWaitCheck('class name', 'UIANotGonnaBeHere', 10000);
     });
 
     it('should work even with a reset in the middle', async function () {
-      await driver.timeouts({protocol: BaseDriver.DRIVER_PROTOCOL.MJSONWP, type: 'command', ms: 60000}, "1dcfe021-8fc8-49bd-8dac-e986d3091b97");
+      await driver.timeouts('command', 60000);
       await driver.implicitWait(4000);
       await impWaitCheck('class name', 'UIANotGonnaBeHere', 4000);
       await driver.reset();

--- a/test/e2e/testapp/timeout/mobile-reset-timeout-specs.js
+++ b/test/e2e/testapp/timeout/mobile-reset-timeout-specs.js
@@ -3,7 +3,7 @@ import desired from '../desired';
 import B from 'bluebird';
 import { throwMatchableError } from '../../helpers/recipes';
 import env from '../../helpers/env';
-import {BaseDriver} from "appium-base-driver";
+
 
 describe('testapp - timeout', function () {
   this.timeout(env.MOCHA_INIT_TIMEOUT);
@@ -15,7 +15,7 @@ describe('testapp - timeout', function () {
     let driver = session.driver;
 
     it('should die with short command timeout even after mobile reset', async function () {
-      await driver.timeouts({protocol: BaseDriver.DRIVER_PROTOCOL.MJSONWP, type: 'command', ms: 3000}, "1dcfe021-8fc8-49bd-8dac-e986d3091b97");
+      await driver.timeouts('command', 3000);
       await driver.reset();
       await B.delay(6500);
       await B.resolve(driver.findElement('accessibility id', 'dont exist dogg'))

--- a/test/e2e/testapp/timeout/short-timeout-specs.js
+++ b/test/e2e/testapp/timeout/short-timeout-specs.js
@@ -3,7 +3,7 @@ import desired from '../desired';
 import B from 'bluebird';
 import { throwMatchableError } from '../../helpers/recipes';
 import env from '../../helpers/env';
-import {BaseDriver} from "appium-base-driver";
+
 
 describe('testapp - timeout', function () {
   this.timeout(env.MOCHA_INIT_TIMEOUT);
@@ -15,7 +15,7 @@ describe('testapp - timeout', function () {
     let driver = session.driver;
 
     it('should die with short command timeout', async function () {
-      await driver.timeouts({protocol: BaseDriver.DRIVER_PROTOCOL.MJSONWP, type: 'command', ms: 3000}, "1dcfe021-8fc8-49bd-8dac-e986d3091b97");
+      await driver.timeouts('command', 3000);
       await B.delay(5500);
       await B.resolve(driver.findElement('accessibility id', 'dont exist dogg'))
         .catch(throwMatchableError)

--- a/test/e2e/testapp/timeout/timeout-via-desired-specs.js
+++ b/test/e2e/testapp/timeout/timeout-via-desired-specs.js
@@ -5,6 +5,7 @@ import { throwMatchableError } from '../../helpers/recipes';
 import env from '../../helpers/env';
 import _ from 'lodash';
 
+
 describe('testapp - timeout', function () {
   this.timeout(env.MOCHA_INIT_TIMEOUT);
 

--- a/test/unit/driver-specs.js
+++ b/test/unit/driver-specs.js
@@ -7,7 +7,7 @@ import { withMocks } from 'appium-test-support';
 import * as teen_process from 'teen_process';
 import { fs } from 'appium-support';
 import xcode from 'appium-xcode';
-import {BaseDriver} from "appium-base-driver";
+
 
 chai.should();
 chai.use(chaiAsPromised);
@@ -47,18 +47,13 @@ describe('driver', function () {
     let driver;
     before(async function () {
       driver = new IosDriver();
-      // await driver.createSession({});
     });
     describe('command', function () {
       it('should exist by default', async function () {
         driver.newCommandTimeoutMs.should.equal(60000);
       });
       it('should be settable through `timeouts`', async function () {
-        await driver.timeouts({protocol: BaseDriver.DRIVER_PROTOCOL.MJSONWP, type: 'command', ms: 20}, "1dcfe021-8fc8-49bd-8dac-e986d3091b97");
-        driver.newCommandTimeoutMs.should.equal(20);
-      });
-      it('should not be settable through `timeouts` for W3C', async function () {
-        await driver.timeouts({protocol: BaseDriver.DRIVER_PROTOCOL.W3C, command: 3000}, "1dcfe021-8fc8-49bd-8dac-e986d3091b97");
+        await driver.timeouts('command', 20);
         driver.newCommandTimeoutMs.should.equal(20);
       });
     });
@@ -67,50 +62,49 @@ describe('driver', function () {
         driver.implicitWaitMs.should.equal(0);
       });
       it('should be settable through `timeouts`', async function () {
-        await driver.timeouts({protocol: BaseDriver.DRIVER_PROTOCOL.MJSONWP, type: 'implicit', ms: 20}, "1dcfe021-8fc8-49bd-8dac-e986d3091b97");
+        await driver.timeouts('implicit', 20);
         driver.implicitWaitMs.should.equal(20);
       });
       it('should be settable through `timeouts` for W3C', async function () {
-        await driver.timeouts({protocol: BaseDriver.DRIVER_PROTOCOL.W3C, implicit: 30}, "1dcfe021-8fc8-49bd-8dac-e986d3091b97");
+        await driver.timeouts(undefined, undefined, undefined, undefined, 30);
         driver.implicitWaitMs.should.equal(30);
       });
     });
     describe('page load', function () {
       it('should be settable through `timeouts`', async function () {
-        let to = driver.pageLoadMs;
-        await driver.timeouts({protocol: BaseDriver.DRIVER_PROTOCOL.MJSONWP, type: 'page load', ms: to + 20}, "1dcfe021-8fc8-49bd-8dac-e986d3091b97");
-        driver.pageLoadMs.should.equal(to + 20);
+        let to = driver.pageLoadMs + 20;
+        await driver.timeouts('page load', to);
+        driver.pageLoadMs.should.equal(to);
       });
       it('should be settable through `timeouts` for W3C', async function () {
-        let to = driver.pageLoadMs;
-        await driver.timeouts({protocol: BaseDriver.DRIVER_PROTOCOL.W3C, pageLoad: to + 30}, "1dcfe021-8fc8-49bd-8dac-e986d3091b97");
-        driver.pageLoadMs.should.equal(to + 30);
+        let to = driver.pageLoadMs + 30;
+        await driver.timeouts(undefined, undefined, undefined, to);
+        driver.pageLoadMs.should.equal(to);
       });
     });
     describe('script', function () {
       it('should be settable through `timeouts`', async function () {
-        let to = driver.asyncWaitMs;
-        await driver.timeouts({protocol: BaseDriver.DRIVER_PROTOCOL.MJSONWP, type: 'script', ms: to + 20}, "1dcfe021-8fc8-49bd-8dac-e986d3091b97");
-        driver.asyncWaitMs.should.equal(to + 20);
+        let to = driver.asyncWaitMs + 20;
+        await driver.timeouts('script', to);
+        driver.asyncWaitMs.should.equal(to);
       });
       it('should be settable through `timeouts` for W3C', async function () {
-        let to = driver.asyncWaitMs;
-        await driver.timeouts({protocol: BaseDriver.DRIVER_PROTOCOL.W3C, script: to + 30}, "1dcfe021-8fc8-49bd-8dac-e986d3091b97");
-        driver.asyncWaitMs.should.equal(to + 30);
+        let to = driver.asyncWaitMs + 30;
+        await driver.timeouts(undefined, undefined, to);
+        driver.asyncWaitMs.should.equal(to);
       });
       it('should be settable through asyncScriptTimeout', async function () {
-        let to = driver.asyncWaitMs;
-        await driver.asyncScriptTimeout(to + 20);
-        driver.asyncWaitMs.should.equal(to + 20);
+        let to = driver.asyncWaitMs + 20;
+        await driver.asyncScriptTimeout(to);
+        driver.asyncWaitMs.should.equal(to);
       });
     });
     describe('script, page load and implicit', function () {
       it('should be settable through `timeouts` for W3C', async function () {
-        let to = driver.asyncWaitMs;
-        await driver.timeouts({protocol: BaseDriver.DRIVER_PROTOCOL.W3C, implicit: 20, pageLoad: to + 20, script: to + 30}, "1dcfe021-8fc8-49bd-8dac-e986d3091b97");
-        driver.implicitWaitMs.should.equal(20);
-        driver.pageLoadMs.should.equal(to + 20);
-        driver.asyncWaitMs.should.equal(to + 30);
+        await driver.timeouts(undefined, undefined, 10, 20, 30);
+        driver.implicitWaitMs.should.equal(30);
+        driver.pageLoadMs.should.equal(20);
+        driver.asyncWaitMs.should.equal(10);
       });
     });
   });


### PR DESCRIPTION
This driver's tests directly access the driver, rather than going through a WebDriver client (for historical reasons, which we don't have time to rectify).

Update timeout calls to handle recent changes (https://github.com/appium/appium-base-driver/commit/b161cb9527073224d60d7d03f83a3fad055581f7, https://github.com/appium/appium-base-driver/commit/5231fae89b09a43283f2d6234c964f88958c1a4c) to timeout handling in `appium-base-driver`.

Fixes #305