### PR TITLE
Throw an exception if app capability is not set and one tries to extract strings

### DIFF
--- a/lib/commands/general.js
+++ b/lib/commands/general.js
@@ -212,7 +212,11 @@ commands.getWindowRect = async function () {
 
 commands.getStrings = async function (language, stringFile = null) {
   log.debug(`Gettings strings for language '${language}' and string file '${stringFile}'`);
-  return await utils.parseLocalizableStrings(_.defaults({language, stringFile}, this.opts));
+  return await utils.parseLocalizableStrings(Object.assign({}, this.opts, {
+    language,
+    stringFile,
+    strictMode: true,
+  }));
 };
 
 commands.setUrl = async function (url) {

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -323,7 +323,9 @@ class IosDriver extends BaseDriver {
 
     await moveBuiltInApp(this.sim);
 
-    this.opts.localizableStrings = await utils.parseLocalizableStrings(this.opts);
+    this.opts.localizableStrings = this.opts.app
+      ? await utils.parseLocalizableStrings(this.opts)
+      : {};
 
     await utils.setBundleIdFromApp(this.opts);
 
@@ -364,7 +366,9 @@ class IosDriver extends BaseDriver {
 
   async startRealDevice () {
     await utils.removeInstrumentsSocket(this.sock);
-    this.opts.localizableStrings = await utils.parseLocalizableStrings(this.opts);
+    this.opts.localizableStrings = this.opts.app
+      ? await utils.parseLocalizableStrings(this.opts)
+      : {};
     await utils.setBundleIdFromApp(this.opts);
     await this.createInstruments();
     await runRealDeviceReset(this.realDevice, this.opts);

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -323,9 +323,7 @@ class IosDriver extends BaseDriver {
 
     await moveBuiltInApp(this.sim);
 
-    this.opts.localizableStrings = this.opts.app
-      ? await utils.parseLocalizableStrings(this.opts)
-      : {};
+    this.opts.localizableStrings = await utils.parseLocalizableStrings(this.opts);
 
     await utils.setBundleIdFromApp(this.opts);
 
@@ -366,9 +364,7 @@ class IosDriver extends BaseDriver {
 
   async startRealDevice () {
     await utils.removeInstrumentsSocket(this.sock);
-    this.opts.localizableStrings = this.opts.app
-      ? await utils.parseLocalizableStrings(this.opts)
-      : {};
+    this.opts.localizableStrings = await utils.parseLocalizableStrings(this.opts);
     await utils.setBundleIdFromApp(this.opts);
     await this.createInstruments();
     await runRealDeviceReset(this.realDevice, this.opts);

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -167,8 +167,7 @@ async function parseLocalizableStrings (opts) {
   } = opts;
 
   if (!app) {
-    logger.debug("Strings extraction is not supported if 'app' capability is not set");
-    return {};
+    throw new Error("Strings extraction is not supported if 'app' capability is not set");
   }
 
   let lprojRoot;

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -164,10 +164,16 @@ async function parseLocalizableStrings (opts) {
     language = 'en',
     localizableStringsDir,
     stringFile,
+    strictMode,
   } = opts;
 
   if (!app) {
-    throw new Error("Strings extraction is not supported if 'app' capability is not set");
+    const message = "Strings extraction is not supported if 'app' capability is not set";
+    if (strictMode) {
+      throw new Error(message);
+    }
+    logger.info(message);
+    return {};
   }
 
   let lprojRoot;
@@ -176,7 +182,11 @@ async function parseLocalizableStrings (opts) {
     if (await fs.exists(lprojRoot)) {
       break;
     }
-    logger.debug(`No '${lprojRoot}' resources folder has been found`);
+    const message = `No '${lprojRoot}' resources folder has been found`;
+    if (strictMode) {
+      throw new Error(message);
+    }
+    logger.debug(message);
   }
   logger.info(`Will extract resource strings from '${lprojRoot}'`);
 
@@ -186,8 +196,12 @@ async function parseLocalizableStrings (opts) {
     if (await fs.exists(dstPath)) {
       resourcePaths.push(dstPath);
     } else {
-      logger.info(`No '${dstPath}' resource file has been found for '${app}'. ` +
-        `Getting all the available strings from '${lprojRoot}'`);
+      const message = `No '${dstPath}' resource file has been found for '${app}'`;
+      if (strictMode) {
+        throw new Error(message);
+      }
+      logger.info(message);
+      logger.info(`Getting all the available strings from '${lprojRoot}'`);
     }
   }
 


### PR DESCRIPTION
It is more logical to throw an exception in the exceptional situation rather than silently returning an empty dict