### PR TITLE
Add verification for resolved paths

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -218,10 +218,11 @@ async function parseLocalizableStrings (opts) {
   }
 
   const resultStrings = {};
+  const toAbsolutePath = function (p) {
+    return path.isAbsolute(p) ? p : path.resolve(process.cwd(), p);
+  };
   for (const resourcePath of resourcePaths) {
-    if (!util.isSubPath(
-      path.isAbsolute(resourcePath) ? resourcePath : path.resolve(process.cwd(), resourcePath),
-      path.isAbsolute(app) ? app : path.resolve(process.cwd(), app))) {
+    if (!util.isSubPath(toAbsolutePath(resourcePath), toAbsolutePath(app))) {
       // security precaution
       throw new Error(`'${resourcePath}' is expected to be located under '${app}'`);
     }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,4 +1,4 @@
-import { fs, plist } from 'appium-support';
+import { fs, plist, util } from 'appium-support';
 import xcode from 'appium-xcode';
 import { extractBundleId } from './app-utils';
 import logger from './logger';
@@ -219,6 +219,12 @@ async function parseLocalizableStrings (opts) {
 
   const resultStrings = {};
   for (const resourcePath of resourcePaths) {
+    if (!util.isSubDir(
+      path.isAbsolute(resourcePath) ? resourcePath : path.resolve(process.cwd(), resourcePath),
+      path.isAbsolute(app) ? app : path.resolve(process.cwd(), app))) {
+      // security precaution
+      throw new Error(`'${resourcePath}' is expected to be located under '${app}'`);
+    }
     try {
       const data = await readResource(resourcePath);
       logger.debug(`Parsed ${_.keys(data).length} string(s) from '${resourcePath}'`);

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -219,7 +219,7 @@ async function parseLocalizableStrings (opts) {
 
   const resultStrings = {};
   for (const resourcePath of resourcePaths) {
-    if (!util.isSubDir(
+    if (!util.isSubPath(
       path.isAbsolute(resourcePath) ? resourcePath : path.resolve(process.cwd(), resourcePath),
       path.isAbsolute(app) ? app : path.resolve(process.cwd(), app))) {
       // security precaution

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "appium-base-driver": "^3.0.0",
     "appium-ios-simulator": "^3.0.0",
     "appium-remote-debugger": "^3.20.0",
-    "appium-support": "^2.12.0",
+    "appium-support": "^2.23.0",
     "appium-xcode": "^3.1.0",
     "asyncbox": "^2.3.1",
     "bluebird": "^3.5.1",


### PR DESCRIPTION
This is to make sure one cannot escape the `app` folder and read any system plist file content by adding ".." to any of the arguments.