### PR TITLE
Clean up window handle code

### DIFF
--- a/lib/commands/context.js
+++ b/lib/commands/context.js
@@ -26,7 +26,6 @@ commands.getContexts = async function () {
   logger.debug('Getting list of available contexts');
   let contexts = await this.getContextsAndViews(false);
 
-
   let mapFn = (context) => context.id.toString();
   if (this.opts.fullContextList) {
     mapFn = (context) => {
@@ -109,9 +108,8 @@ commands.getWindowHandles = async function () {
     throw new errors.NotImplementedError();
   }
 
-  let pageArray = await this.listWebFrames();
-  this.windowHandleCache = _.map(pageArray, this.massagePage);
-  let idArray = _.map(this.windowHandleCache, 'id');
+  this.windowHandleCache = await this.listWebFrames(false);
+  const idArray = _.map(this.windowHandleCache, 'id');
   // since we use this.contexts to manage selecting debugger pages, make
   // sure it gets populated even if someone did not use the
   // getContexts method
@@ -160,6 +158,7 @@ extensions.initAutoWebview = async function () {
 extensions.getContextsAndViews = async function (useUrl = true) {
   logger.debug('Retrieving contexts and views');
   let webviews = await this.listWebFrames(useUrl);
+
   let ctxs = [{id: NATIVE_WIN, view: {}}];
   this.contexts = [NATIVE_WIN];
   for (let view of webviews) {
@@ -364,7 +363,7 @@ extensions.onPageChange = async function (pageChangeNotification) {
     this.selectingNewPage = false;
     this.curContext = `${appIdKey}.${newPage}`;
   }
-  this.windowHandleCache = _.map(pageArray, this.massagePage);
+  this.windowHandleCache = pageArray;
 };
 
 extensions.getLatestWebviewContextForTitle = async function (regExp) {


### PR DESCRIPTION
We want to not filter by url, or else we don't actually get all the window handles (see https://github.com/appium/appium/issues/11484).

Further, `this.massagePage` does not exist, so mapping through it does not do anything at all. This was a holdover from Appium 1.4 (https://github.com/appium/appium/blob/1.4/lib/devices/ios/ios-controller.js#L1717-L1720).