### PR TITLE
Move authorize-ios into package

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,14 @@
 env:
   global:
     - MOCHA_INIT_TIMEOUT=600000
+    - RECURSIVE=--recursive
   matrix:
   # Run tests in parellel
-    - DEVICE=ios93 TEST=unit COVERALLS=1
-    - DEVICE=ios93 TEST=e2e/driver RECURSIVE=1 IWDP=1
-    - DEVICE=ios93 TEST=e2e/testapp RECURSIVE=1
-    - DEVICE=ios93 TEST=e2e/uicatalog RECURSIVE=1
-    - DEVICE=ios93 TEST=e2e/safari RECURSIVE=1
+    - DEVICE=ios93 TEST=unit RECURSIVE= COVERALLS=1
+    - DEVICE=ios93 TEST=e2e/driver IWDP=1
+    - DEVICE=ios93 TEST=e2e/testapp
+    - DEVICE=ios93 TEST=e2e/uicatalog
+    - DEVICE=ios93 TEST=e2e/safari
 language: node_js
 os: osx
 osx_image: xcode7.3
@@ -24,10 +25,6 @@ before_script:
   - npm install
 script:
   - npm run lint
-  - if [ -n "$RECURSIVE" ]; then
-      npm run mocha -- --recursive build/test/$TEST -g @skip-ci -i --exit;
-    else
-      npm run mocha -- build/test/$TEST -g @skip-ci -i --exit;
-    fi
+  - npm run mocha -- $RECURSIVE build/test/$TEST -g @skip-ci -i --exit;
 after_success:
   - if [ -n "$COVERALLS" ]; then npm run coverage; fi

--- a/LICENSE
+++ b/LICENSE
@@ -1,13 +1,201 @@
-Copyright 2012-2016 JS Foundation and other contributors
+Apache License
+Version 2.0, January 2004
+http://www.apache.org/licenses/
 
-   Licensed under the Apache License, Version 2.0 (the "License");
-   you may not use this file except in compliance with the License.
-   You may obtain a copy of the License at
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
-       http://www.apache.org/licenses/LICENSE-2.0
+1. Definitions.
 
-   Unless required by applicable law or agreed to in writing, software
-   distributed under the License is distributed on an "AS IS" BASIS,
-   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-   See the License for the specific language governing permissions and
-   limitations under the License.
+"License" shall mean the terms and conditions for use, reproduction,
+and distribution as defined by Sections 1 through 9 of this document.
+
+"Licensor" shall mean the copyright owner or entity authorized by
+the copyright owner that is granting the License.
+
+"Legal Entity" shall mean the union of the acting entity and all
+other entities that control, are controlled by, or are under common
+control with that entity. For the purposes of this definition,
+"control" means (i) the power, direct or indirect, to cause the
+direction or management of such entity, whether by contract or
+otherwise, or (ii) ownership of fifty percent (50%) or more of the
+outstanding shares, or (iii) beneficial ownership of such entity.
+
+"You" (or "Your") shall mean an individual or Legal Entity
+exercising permissions granted by this License.
+
+"Source" form shall mean the preferred form for making modifications,
+including but not limited to software source code, documentation
+source, and configuration files.
+
+"Object" form shall mean any form resulting from mechanical
+transformation or translation of a Source form, including but
+not limited to compiled object code, generated documentation,
+and conversions to other media types.
+
+"Work" shall mean the work of authorship, whether in Source or
+Object form, made available under the License, as indicated by a
+copyright notice that is included in or attached to the work
+(an example is provided in the Appendix below).
+
+"Derivative Works" shall mean any work, whether in Source or Object
+form, that is based on (or derived from) the Work and for which the
+editorial revisions, annotations, elaborations, or other modifications
+represent, as a whole, an original work of authorship. For the purposes
+of this License, Derivative Works shall not include works that remain
+separable from, or merely link (or bind by name) to the interfaces of,
+the Work and Derivative Works thereof.
+
+"Contribution" shall mean any work of authorship, including
+the original version of the Work and any modifications or additions
+to that Work or Derivative Works thereof, that is intentionally
+submitted to Licensor for inclusion in the Work by the copyright owner
+or by an individual or Legal Entity authorized to submit on behalf of
+the copyright owner. For the purposes of this definition, "submitted"
+means any form of electronic, verbal, or written communication sent
+to the Licensor or its representatives, including but not limited to
+communication on electronic mailing lists, source code control systems,
+and issue tracking systems that are managed by, or on behalf of, the
+Licensor for the purpose of discussing and improving the Work, but
+excluding communication that is conspicuously marked or otherwise
+designated in writing by the copyright owner as "Not a Contribution."
+
+"Contributor" shall mean Licensor and any individual or Legal Entity
+on behalf of whom a Contribution has been received by Licensor and
+subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of
+this License, each Contributor hereby grants to You a perpetual,
+worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+copyright license to reproduce, prepare Derivative Works of,
+publicly display, publicly perform, sublicense, and distribute the
+Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of
+this License, each Contributor hereby grants to You a perpetual,
+worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+(except as stated in this section) patent license to make, have made,
+use, offer to sell, sell, import, and otherwise transfer the Work,
+where such license applies only to those patent claims licensable
+by such Contributor that are necessarily infringed by their
+Contribution(s) alone or by combination of their Contribution(s)
+with the Work to which such Contribution(s) was submitted. If You
+institute patent litigation against any entity (including a
+cross-claim or counterclaim in a lawsuit) alleging that the Work
+or a Contribution incorporated within the Work constitutes direct
+or contributory patent infringement, then any patent licenses
+granted to You under this License for that Work shall terminate
+as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the
+Work or Derivative Works thereof in any medium, with or without
+modifications, and in Source or Object form, provided that You
+meet the following conditions:
+
+(a) You must give any other recipients of the Work or
+Derivative Works a copy of this License; and
+
+(b) You must cause any modified files to carry prominent notices
+stating that You changed the files; and
+
+(c) You must retain, in the Source form of any Derivative Works
+that You distribute, all copyright, patent, trademark, and
+attribution notices from the Source form of the Work,
+excluding those notices that do not pertain to any part of
+the Derivative Works; and
+
+(d) If the Work includes a "NOTICE" text file as part of its
+distribution, then any Derivative Works that You distribute must
+include a readable copy of the attribution notices contained
+within such NOTICE file, excluding those notices that do not
+pertain to any part of the Derivative Works, in at least one
+of the following places: within a NOTICE text file distributed
+as part of the Derivative Works; within the Source form or
+documentation, if provided along with the Derivative Works; or,
+within a display generated by the Derivative Works, if and
+wherever such third-party notices normally appear. The contents
+of the NOTICE file are for informational purposes only and
+do not modify the License. You may add Your own attribution
+notices within Derivative Works that You distribute, alongside
+or as an addendum to the NOTICE text from the Work, provided
+that such additional attribution notices cannot be construed
+as modifying the License.
+
+You may add Your own copyright statement to Your modifications and
+may provide additional or different license terms and conditions
+for use, reproduction, or distribution of Your modifications, or
+for any such Derivative Works as a whole, provided Your use,
+reproduction, and distribution of the Work otherwise complies with
+the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise,
+any Contribution intentionally submitted for inclusion in the Work
+by You to the Licensor shall be under the terms and conditions of
+this License, without any additional terms or conditions.
+Notwithstanding the above, nothing herein shall supersede or modify
+the terms of any separate license agreement you may have executed
+with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade
+names, trademarks, service marks, or product names of the Licensor,
+except as required for reasonable and customary use in describing the
+origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or
+agreed to in writing, Licensor provides the Work (and each
+Contributor provides its Contributions) on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+implied, including, without limitation, any warranties or conditions
+of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+PARTICULAR PURPOSE. You are solely responsible for determining the
+appropriateness of using or redistributing the Work and assume any
+risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory,
+whether in tort (including negligence), contract, or otherwise,
+unless required by applicable law (such as deliberate and grossly
+negligent acts) or agreed to in writing, shall any Contributor be
+liable to You for damages, including any direct, indirect, special,
+incidental, or consequential damages of any character arising as a
+result of this License or out of the use or inability to use the
+Work (including but not limited to damages for loss of goodwill,
+work stoppage, computer failure or malfunction, or any and all
+other commercial damages or losses), even if such Contributor
+has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing
+the Work or Derivative Works thereof, You may choose to offer,
+and charge a fee for, acceptance of support, warranty, indemnity,
+or other liability obligations and/or rights consistent with this
+License. However, in accepting such obligations, You may act only
+on Your own behalf and on Your sole responsibility, not on behalf
+of any other Contributor, and only if You agree to indemnify,
+defend, and hold each Contributor harmless for any liability
+incurred by, or claims asserted against, such Contributor by reason
+of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work.
+
+To apply the Apache License to your work, attach the following
+boilerplate notice, with the fields enclosed by brackets "{}"
+replaced with your own identifying information. (Don't include
+the brackets!)  The text should be enclosed in the appropriate
+comment syntax for the file format. We also recommend that a
+file or class name and description of purpose be included on the
+same "printed page" as the copyright notice for easier
+identification within third-party archives.
+
+Copyright JS Foundation and other contributors, https://js.foundation
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/README.md
+++ b/README.md
@@ -27,6 +27,48 @@ Appium iOS Driver supports iOS versions 8+
 npm install appium-ios-driver
 ```
 
+## Authorization for automation support
+
+On some systems Instruments is not authorized to automate iOS devices. This package
+comes with a little utility that pre-authorizes Instruments to run UIAutomation
+scripts.
+
+Running the authorization script will bring up an alert that prompts the user
+to input their `sudo` password. There is no way around this.
+
+### Command line usage
+
+If this package has been installed globally (either as part of an Appium
+installation, with `npm install -g appium`, or individually, with
+`npm install -g appium-ios-driver`), a _global_ command line utility will be
+installed, so you simply need to invoke it:
+
+```
+$ authorize-ios
+```
+
+### Programmatic usage
+
+To invoke programmatically (in, for instance, a test runner) is as simple as
+importing and invoking the `authorize` function, which returns a
+[Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Using_promises):
+
+```
+npm install -S appium-ios-driver
+```
+
+```js
+import { authorize } from 'appium-ios-driver';
+
+authorize()
+  .then(function () {
+    console.log('iOS authorized!');
+  })
+  .catch(function (err) {
+    console.error(`Error authorizing: ${err.message}`);
+  });
+```
+
 ## Usage
 Import iOS Driver, set [desired capabilities](http://appium.io/slate/en/1.5/?javascript#appium-server-capabilities) and create a session:
 

--- a/bin/authorize-ios.js
+++ b/bin/authorize-ios.js
@@ -1,0 +1,78 @@
+#!/usr/bin/env node
+import { exec } from 'teen_process';
+import xcode from 'appium-xcode';
+import { fs, logger } from 'appium-support';
+import path from 'path';
+import _glob from 'glob';
+import B from 'bluebird';
+import _ from 'lodash';
+
+
+const glob = B.promisify(_glob);
+const log = logger.getLogger('AuthorizeIOS');
+
+async function authorize (insecure) {
+  let xcodeDir;
+  let user;
+
+  try {
+    // enable developer tools
+    log.info('Enabling DevToolsSecurity');
+    await exec('DevToolsSecurity', ['--enable']);
+    // update security db -- removes authorization prompt
+    log.info(`Updating security db for ${insecure ? 'insecure' : 'developer'} access`);
+    const cmd = 'security';
+    const args = [
+      'authorizationdb', 'write', 'system.privilege.taskport',
+      (insecure ? 'allow' : 'is-developer'),
+    ];
+    await exec(cmd, args);
+
+    log.info('Granting access to built-in simulator apps');
+    if (!process.env.HOME) {
+      throw new Error('Could not determine your $HOME');
+    }
+
+    user = /\/([^/]+)$/.exec(process.env.HOME)[1];
+    xcodeDir = await xcode.getPath();
+    log.info(`The xcode directory is: ${xcodeDir}`);
+  } catch (e) {
+    log.errorAndThrow(e);
+  }
+
+  // change permission
+  const olderXcodeSimulatorPath = path.resolve(xcodeDir,
+                              'Platforms/iPhoneSimulator.platform/' +
+                              'Developer/SDKs/iPhoneSimulator*.sdk/Applications');
+  const newerXcodeSimulatorPath = path.resolve('/Library/Developer/CoreSimulator/' +
+                              'Profiles/Runtimes/iOS *.simruntime/' +
+                              'Contents/Resources/RuntimeRoot/Applications/');
+
+  const directories = [
+    ...await glob(olderXcodeSimulatorPath),
+    ...await glob(newerXcodeSimulatorPath),
+  ].filter(async (dir) => await fs.exists(dir));
+
+  if (_.isEmpty(directories)) {
+    log.warn('No iOS sim app directories to change. Skipping.');
+    return;
+  }
+
+  log.info(`Changing ownership to '${user}' on directories: ${directories.join(', ')}`);
+  try {
+    const args = ['-R', `${user}:`, ...directories];
+    await exec('chown', args);
+  } catch (err) {
+    log.error(`Encountered an issue changing user priveledges ` +
+                 `for iOS sim app dirs: ${directories}`);
+    log.error(`Error was: ${err.message}`);
+  }
+}
+
+if (require.main === module) {
+  authorize();
+}
+
+
+export { authorize };
+export default authorize;

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -3,9 +3,17 @@
 const gulp = require('gulp');
 const boilerplate = require('appium-gulp-plugins').boilerplate.use(gulp);
 
+
 boilerplate({
   build: 'appium-ios-driver',
-  files: ['*.js', 'lib/**/*.js', 'test/**/*.js', '!gulpfile.js', '!test/assets/**/*.js'],
+  files: [
+    '*.js',
+    'bin/**/*.js',
+    'lib/**/*.js',
+    'test/**/*.js',
+    '!gulpfile.js',
+    '!test/assets/**/*.js',
+  ],
   test: {
     files: ['${testDir}/**/*-specs.js', '!${testDir}/e2e/**']
   },

--- a/index.js
+++ b/index.js
@@ -62,3 +62,8 @@ export { IOSLog, IOSCrashLog, IOSPerformanceLog };
 import * as appUtils from './lib/app-utils';
 
 export { appUtils };
+
+// iOS authorize
+import { authorize } from './bin/authorize-ios';
+
+export { authorize };

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
   ],
   "main": "./build/index.js",
   "bin": {
-    "xcode-iwd": "./bin/xcode-iwd.sh"
+    "xcode-iwd": "./bin/xcode-iwd.sh",
+    "authorize-ios": "./build/bin/authorize-ios.js"
   },
   "directories": {
     "lib": "lib"

--- a/test/unit/bin/authorize-ios-specs.js
+++ b/test/unit/bin/authorize-ios-specs.js
@@ -1,0 +1,46 @@
+import authorize from '../../../bin/authorize-ios';
+import * as teen_process from 'teen_process';
+import xcode from 'appium-xcode';
+import path from 'path';
+import sinon from 'sinon';
+import chai from 'chai';
+import chaiAsPromised from 'chai-as-promised';
+import _ from 'lodash';
+
+
+chai.should();
+chai.use(chaiAsPromised);
+
+let sandbox = null;
+let SANDBOX = Symbol();
+let mocks = {};
+let libs = {teen_process, xcode, path};
+
+describe('Authorize test', function () {
+  beforeEach(function () {
+    sandbox = sinon.createSandbox();
+    mocks[SANDBOX] = sandbox;
+    for (const [key, value] of _.toPairs(libs)) {
+      mocks[key] = sandbox.mock(value);
+    }
+  });
+
+  afterEach(function () {
+    sandbox.restore();
+  });
+
+  it('should throw an error', async function () {
+    mocks.teen_process.expects('exec').once().withExactArgs('DevToolsSecurity', ['--enable']).throws(new Error('Error'));
+    await authorize().should.eventually.be.rejectedWith('Error');
+    mocks[SANDBOX].verify();
+  });
+
+  it('should pass all mocks', async function () {
+    mocks.teen_process.expects('exec').atLeast(2);
+
+    mocks.xcode.expects('getPath').once().returns('xcodeDir/Applications/Xcode.app/Contents/Developer');
+
+    await authorize();
+    mocks[SANDBOX].verify();
+  });
+});


### PR DESCRIPTION
The `authorize-ios` utility is only used for `appium-ios-driver`, so there is no need to have it be separate. 

The final vestiges of dearchitecturing.