### PR TITLE
Allow for stdout logging from managed iwdp

### DIFF
--- a/lib/desired-caps.js
+++ b/lib/desired-caps.js
@@ -14,7 +14,6 @@ const desiredCapConstraints = {
   app: {
     isString: true
   },
-
   launchTimeout: {
     // recognize the cap,
     // but validate in the driver#validateDesiredCaps method
@@ -118,6 +117,12 @@ const desiredCapConstraints = {
     isBoolean: true
   },
   ignoreAboutBlankUrl: {
+    isBoolean: true
+  },
+  startIWDP: {
+    isBoolean: true
+  },
+  iwdpLogging: {
     isBoolean: true
   },
 };

--- a/lib/desired-caps.js
+++ b/lib/desired-caps.js
@@ -122,7 +122,7 @@ const desiredCapConstraints = {
   startIWDP: {
     isBoolean: true
   },
-  iwdpLogging: {
+  showIWDPLog: {
     isBoolean: true
   },
 };

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -494,7 +494,11 @@ class IosDriver extends BaseDriver {
 
   async startIWDP () {
     if (this.opts.startIWDP) {
-      this.iwdpServer = new IWDP(this.opts.webkitDebugProxyPort, this.opts.udid, !!this.opts.iwdpLogging);
+      this.iwdpServer = new IWDP({
+        webkitDebugProxyPort: this.opts.webkitDebugProxyPort,
+        udid: this.opts.udid,
+        logStdout: !!this.opts.showIWDPLog,
+      });
       await this.iwdpServer.start();
     }
   }

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -494,7 +494,7 @@ class IosDriver extends BaseDriver {
 
   async startIWDP () {
     if (this.opts.startIWDP) {
-      this.iwdpServer = new IWDP(this.opts.webkitDebugProxyPort, this.opts.udid);
+      this.iwdpServer = new IWDP(this.opts.webkitDebugProxyPort, this.opts.udid, !!this.opts.iwdpLogging);
       await this.iwdpServer.start();
     }
   }

--- a/lib/iwdp.js
+++ b/lib/iwdp.js
@@ -11,10 +11,11 @@ const MAX_RETRIES = 10;
 let iwdpLogger = baseLogger.getLogger('IWDP');
 
 class IWDP extends EventEmitter {
-
-  constructor (webkitDebugProxyPort = 27753, udid = null) {
+  constructor (webkitDebugProxyPort = 27753, udid = null, logStdout = false) {
     super();
+
     this.udid = udid;
+    this.logStdout = !!logStdout;
     this.attempts = 0;
     this.port = webkitDebugProxyPort;
     this.process = this.createIWDPProcess();
@@ -22,9 +23,13 @@ class IWDP extends EventEmitter {
   }
 
   createIWDPProcess () {
-    let process = new SubProcess(IWDP_CMD, ['-c', `${this.udid}:${this.port}`, '-d']); // (see https://github.com/google/ios-webkit-debug-proxy for reference)
+    // (see https://github.com/google/ios-webkit-debug-proxy for reference)
+    const process = new SubProcess(IWDP_CMD, ['-c', `${this.udid}:${this.port}`, '-d']);
     process.on('exit', () => this.onExit());
     process.on('lines-stderr', iwdpLogger.error);
+    if (this.logStdout) {
+      process.on('lines-stdout', iwdpLogger.debug);
+    }
     return process;
   }
 

--- a/lib/iwdp.js
+++ b/lib/iwdp.js
@@ -11,13 +11,13 @@ const MAX_RETRIES = 10;
 let iwdpLogger = baseLogger.getLogger('IWDP');
 
 class IWDP extends EventEmitter {
-  constructor (webkitDebugProxyPort = 27753, udid = null, logStdout = false) {
+  constructor (opts = {}) {
     super();
 
-    this.udid = udid;
-    this.logStdout = !!logStdout;
+    this.udid = opts.udid;
+    this.logStdout = !!opts.logStdout;
     this.attempts = 0;
-    this.port = webkitDebugProxyPort;
+    this.port = opts.webkitDebugProxyPort || 27753;
     this.process = this.createIWDPProcess();
     this.endpoint = `http://localhost:${this.port}`;
   }

--- a/lib/iwdp.js
+++ b/lib/iwdp.js
@@ -5,16 +5,17 @@ import request from 'request-promise';
 import { retryInterval } from 'asyncbox';
 import { fs, logger as baseLogger } from 'appium-support';
 
+
 const IWDP_CMD = 'ios_webkit_debug_proxy';
 const MAX_RETRIES = 10;
 
-let iwdpLogger = baseLogger.getLogger('IWDP');
+const iwdpLogger = baseLogger.getLogger('IWDP');
 
 class IWDP extends EventEmitter {
   constructor (opts = {}) {
     super();
 
-    this.udid = opts.udid;
+    this.udid = opts.udid || null;
     this.logStdout = !!opts.logStdout;
     this.attempts = 0;
     this.port = opts.webkitDebugProxyPort || 27753;

--- a/test/e2e/driver/iwdp-e2e-specs.js
+++ b/test/e2e/driver/iwdp-e2e-specs.js
@@ -5,6 +5,8 @@ import IWDP from '../../../lib/iwdp';
 import { SubProcess } from 'teen_process';
 import request from 'request-promise';
 import B from 'bluebird';
+
+
 chai.should();
 chai.use(chaiAsPromised);
 


### PR DESCRIPTION
Two things:
1. We do not list the `startIWDP` for `appium-ios-driver`, though it is available.
1. There is no way to get the stdout logging from `iwdp`. Error logs get outputted but not debug. It makes sense that they not be printed by default, since they are verbose, but being able to view them when Appium is managing `iwdp` would be useful.