### PR TITLE
Add webkitDebugProxyPort to constraints

### DIFF
--- a/lib/desired-caps.js
+++ b/lib/desired-caps.js
@@ -101,6 +101,9 @@ const desiredCapConstraints = {
   webkitResponseTimeout: {
     isNumber: true
   },
+  webkitDebugProxyPort: {
+    isNumber: true
+  },
   remoteDebugProxy: {
     isString: true
   },


### PR DESCRIPTION
Add `webkitDebugProxyPort` to the desired cap constraints (it exists in the code, and in the constraints for `appium-xcuitest-driver`, where it needs to be removed).