### PR TITLE
pass platformversion and issafari to WebKitRemoteDebugger in real device

### DIFF
--- a/lib/commands/context.js
+++ b/lib/commands/context.js
@@ -203,6 +203,8 @@ extensions.listWebFrames = async function listWebFrames (useUrl = true) {
       this.remote = new WebKitRemoteDebugger({
         port: this.opts.webkitDebugProxyPort,
         webkitResponseTimeout: this.opts.webkitResponseTimeout,
+        platformVersion: this.opts.platformVersion,
+        isSafari: this.isSafari,
       });
       pageArray = await this.remote.pageArrayFromJson(this.opts.ignoreAboutBlankUrl);
     } catch (err) {

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "@babel/runtime": "^7.0.0",
     "appium-base-driver": "^3.0.0",
     "appium-ios-simulator": "^3.9.0",
-    "appium-remote-debugger": "^4.0.0",
+    "appium-remote-debugger": "^4.1.0",
     "appium-support": "^2.25.0",
     "appium-xcode": "^3.1.0",
     "asyncbox": "^2.3.1",


### PR DESCRIPTION
When I investigated https://github.com/appium/appium/issues/12398#issuecomment-478270634 , I found this.

In https://github.com/appium/appium-remote-debugger/pull/122/files#diff-79c9727f17e7f83c1c33f14bbe7a55e2R23 , the platfotmVersion should be `12.1` for example.
But in real device, `WebKitRemoteDebugger` does not pass the value to the class. So, `opts.platformVersion` becomes `undefined`. As the result, https://github.com/appium/appium-remote-debugger/pull/122/files#diff-17ff41d4312838bfdfc249e22bb720f8R43 never be `true`.

After this change, I ensured https://github.com/appium/appium/issues/12398#issuecomment-478270634 did not happen in my environment.