### PR TITLE
iOS 12.2, fix isSafari param

### DIFF
--- a/lib/commands/context.js
+++ b/lib/commands/context.js
@@ -174,6 +174,7 @@ extensions.getNewRemoteDebugger = async function getNewRemoteDebugger () { // es
     useNewSafari: this.useNewSafari(),
     pageLoadMs: this.pageLoadMs,
     platformVersion: this.opts.platformVersion,
+    isSafari: this.isSafari(),
     remoteDebugProxy: this.opts.remoteDebugProxy,
     garbageCollectOnExecute: util.hasValue(this.opts.safariGarbageCollect)
       ? !!this.opts.safariGarbageCollect
@@ -204,7 +205,7 @@ extensions.listWebFrames = async function listWebFrames (useUrl = true) {
         port: this.opts.webkitDebugProxyPort,
         webkitResponseTimeout: this.opts.webkitResponseTimeout,
         platformVersion: this.opts.platformVersion,
-        isSafari: this.isSafari,
+        isSafari: this.isSafari(),
       });
       pageArray = await this.remote.pageArrayFromJson(this.opts.ignoreAboutBlankUrl);
     } catch (err) {


### PR DESCRIPTION
The isSafari param is not correctly set. This causes problems on apps using WebView and iOS 12.2+