### PR TITLE
Mock xcrun calls

### DIFF
--- a/test/unit/device-specs.js
+++ b/test/unit/device-specs.js
@@ -1,9 +1,11 @@
 import { IosDriver } from '../../lib/driver';
 import { uiauto } from '../..';
 import chai from 'chai';
+import chaiAsPromised from 'chai-as-promised';
 import sinon from 'sinon';
 
 chai.should();
+chai.use(chaiAsPromised);
 
 const PLUS_HEIGHT = 736;
 const NONPLUS_HEIGHT = 568;

--- a/test/unit/file-movement-specs.js
+++ b/test/unit/file-movement-specs.js
@@ -2,6 +2,12 @@ import { IosDriver } from '../..';
 import sinon from 'sinon';
 import path from 'path';
 import { tempDir, fs, zip } from 'appium-support';
+import chai from 'chai';
+import chaiAsPromised from 'chai-as-promised';
+
+
+chai.should();
+chai.use(chaiAsPromised);
 
 describe('File Movement', function () {
   let driver = new IosDriver();

--- a/test/unit/utils-specs.js
+++ b/test/unit/utils-specs.js
@@ -1,26 +1,34 @@
-// transpile:mocha
-
 import * as utils from '../../lib/utils';
 import chai from 'chai';
 import chaiAsPromised from 'chai-as-promised';
+import { withMocks } from 'appium-test-support';
+import xcode from 'appium-xcode';
+
 
 chai.should();
 chai.use(chaiAsPromised);
 
-describe('prepareIosOpts', function () {
+describe('prepareIosOpts', withMocks({xcode}, (mocks) => {
+  beforeEach(function () {
+    mocks.xcode.expects('getMaxIOSSDK')
+      .once().returns('9.3');
+  });
+  afterEach(function () {
+    mocks.verify();
+  });
   it('should use instruments without delay by default', function () {
-    let opts = {};
+    const opts = {};
     utils.prepareIosOpts(opts);
     opts.withoutDelay.should.be.true;
   });
   it('should use instruments without delay if explicitly not using native instruments', function () {
-    let opts = {nativeInstrumentsLib: false};
+    const opts = {nativeInstrumentsLib: false};
     utils.prepareIosOpts(opts);
     opts.withoutDelay.should.be.true;
   });
   it('should not use instruments without delay if using native intruments', function () {
-    let opts = {nativeInstrumentsLib: true};
+    const opts = {nativeInstrumentsLib: true};
     utils.prepareIosOpts(opts);
     opts.withoutDelay.should.be.false;
   });
-});
+}));

--- a/test/unit/utils-specs.js
+++ b/test/unit/utils-specs.js
@@ -16,19 +16,19 @@ describe('prepareIosOpts', withMocks({xcode}, (mocks) => {
   afterEach(function () {
     mocks.verify();
   });
-  it('should use instruments without delay by default', function () {
+  it('should use instruments without delay by default', async function () {
     const opts = {};
-    utils.prepareIosOpts(opts);
+    await utils.prepareIosOpts(opts);
     opts.withoutDelay.should.be.true;
   });
-  it('should use instruments without delay if explicitly not using native instruments', function () {
+  it('should use instruments without delay if explicitly not using native instruments', async function () {
     const opts = {nativeInstrumentsLib: false};
-    utils.prepareIosOpts(opts);
+    await utils.prepareIosOpts(opts);
     opts.withoutDelay.should.be.true;
   });
-  it('should not use instruments without delay if using native intruments', function () {
+  it('should not use instruments without delay if using native intruments', async function () {
     const opts = {nativeInstrumentsLib: true};
-    utils.prepareIosOpts(opts);
+    await utils.prepareIosOpts(opts);
     opts.withoutDelay.should.be.false;
   });
 }));


### PR DESCRIPTION
Three unit tests still actually made system calls to `xcrun`. Mock those.

@mykola-mokhnach Can you run the existing utils unit tests (`npm run build && npx mocha -R spec build/test/unit/utils-specs.js`) before trying this patch? If the same three `TypeError` errors come up, then that kind of confirms this is the place. Then with this patch those should be gone.

That would also confirm that the problem is somewhere in the system call, which sucks. I would suggest at that point going into `teen_process` and trying to `exec` the `xcrun --sdk iphonesimulator --show-sdk-version` and see where the error comes up.

I wish I could reproduce this so I could investigate. :(