### PR TITLE
Add safariShowFullResponse cap

### DIFF
--- a/lib/commands/context.js
+++ b/lib/commands/context.js
@@ -177,6 +177,7 @@ extensions.getNewRemoteDebugger = async function getNewRemoteDebugger () { // es
     isSafari: this.isSafari(),
     remoteDebugProxy: this.opts.remoteDebugProxy,
     garbageCollectOnExecute: false,
+    logFullResponse: !!this.opts.safariShowFullResponse,
   });
 };
 
@@ -204,6 +205,8 @@ extensions.listWebFrames = async function listWebFrames (useUrl = true) {
         webkitResponseTimeout: this.opts.webkitResponseTimeout,
         platformVersion: this.opts.platformVersion,
         isSafari: this.isSafari(),
+        garbageCollectOnExecute: false,
+        logFullResponse: !!this.opts.safariShowFullResponse,
       });
       pageArray = await this.remote.pageArrayFromJson(this.opts.ignoreAboutBlankUrl);
     } catch (err) {

--- a/lib/desired-caps.js
+++ b/lib/desired-caps.js
@@ -57,6 +57,9 @@ const desiredCapConstraints = {
   safariOpenLinksInBackground: {
     isBoolean: true
   },
+  safariShowFullResponse: {
+    isBoolean: true
+  },
   keepKeyChains: {
     isBoolean: true
   },


### PR DESCRIPTION
 For logging verbosity reasons we truncate the data the Web Inspector returns, but it is sometimes useful to see it, in full. This cap gives access to that information.