### PR TITLE
Remove safariGarbageCollect cap

### DIFF
--- a/lib/commands/context.js
+++ b/lib/commands/context.js
@@ -176,9 +176,7 @@ extensions.getNewRemoteDebugger = async function getNewRemoteDebugger () { // es
     platformVersion: this.opts.platformVersion,
     isSafari: this.isSafari(),
     remoteDebugProxy: this.opts.remoteDebugProxy,
-    garbageCollectOnExecute: util.hasValue(this.opts.safariGarbageCollect)
-      ? !!this.opts.safariGarbageCollect
-      : true,
+    garbageCollectOnExecute: false,
   });
 };
 

--- a/lib/desired-caps.js
+++ b/lib/desired-caps.js
@@ -57,9 +57,6 @@ const desiredCapConstraints = {
   safariOpenLinksInBackground: {
     isBoolean: true
   },
-  safariGarbageCollect: {
-    isBoolean: true
-  },
   keepKeyChains: {
     isBoolean: true
   },


### PR DESCRIPTION
This feature appears to have _never_ worked in this driver (see, for instance, https://travis-ci.org/appium/appium-ios-driver/jobs/412796191#L1608).

The problem now is that the new `appium-remote-debugger` switches protocols based on whether the Web Inspector throw `domain not found` errors. This causes the tests to fail.

This will fix the build.

I will open another PR to add the cap to `appium-xcuitest-driver`, where it works.