### PR TITLE
fix: better handling page selection on page change in web view

### DIFF
--- a/lib/commands/context.js
+++ b/lib/commands/context.js
@@ -363,9 +363,18 @@ extensions.onPageChange = async function onPageChange (pageChangeNotification) {
 
   if (util.hasValue(newPage)) {
     this.selectingNewPage = true;
-    await this.remote.selectPage(appIdKey, parseInt(newPage, 10));
-    this.selectingNewPage = false;
-    this.curContext = `${appIdKey}.${newPage}`;
+    const oldContext = this.curContext;
+    try {
+      this.curContext = `${appIdKey}.${newPage}`;
+      await this.remote.selectPage(appIdKey, parseInt(newPage, 10));
+    } catch (err) {
+      // if there was a problem, do not stay in the new context, which we did
+      // not successfully get into in the Web Inspector
+      this.curContext = oldContext;
+      throw err;
+    } finally {
+      this.selectingNewPage = false;
+    }
   }
   this.windowHandleCache = pageArray;
 };


### PR DESCRIPTION
Move setting the context to _before_ setting the page in the remote debugger. This way subsequent calls to functions will get the new context, rather than the old. Since `onPageChange` is called asynchronously, whenever the Web Inspector notifies of a page change, the automating script can be trying to do things with the webview while this change is happening.

In `appium-remote-debugger` setting the page happens immediately but it sometimes takes a while to get a confirmation back from the Web Inspector.

First part of working on https://github.com/appium/appium/issues/13263