### PR TITLE
fix: turn off greenkeeper for node-simctl

### DIFF
--- a/package.json
+++ b/package.json
@@ -104,6 +104,7 @@
     "ignore": [
       "appium-remote-debugger",
       "chai",
+      "node-simctl",
       "xpath"
     ]
   }


### PR DESCRIPTION
`node-simctl` is diverging from that needed/used by this package. Make Greenkeeper ignore updates.