### PR TITLE
chore: Bump xmldom from 0.6.0 to 0.8.0

### DIFF
--- a/lib/commands/find.js
+++ b/lib/commands/find.js
@@ -3,7 +3,7 @@ import { util } from 'appium-support';
 import { errors } from 'appium-base-driver';
 import _ from 'lodash';
 import js2xml from 'js2xmlparser2';
-import XMLDom from 'xmldom';
+import XMLDom from '@xmldom/xmldom';
 import xpath from 'xpath';
 import B from 'bluebird';
 import { unwrapEl } from '../utils';

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "source-map-support": "^0.x",
     "teen_process": "^1.6.0",
     "through": "^2.3.8",
-    "xmldom": "^0.x",
+    "@xmldom/xmldom": "^0.x",
     "xpath": "^0.x"
   },
   "scripts": {

--- a/test/e2e/testapp/source-specs.js
+++ b/test/e2e/testapp/source-specs.js
@@ -1,6 +1,6 @@
 import setup from '../setup-base';
 import desired from './desired';
-import { DOMParser as XMLDom } from 'xmldom';
+import { DOMParser as XMLDom } from '@xmldom/xmldom';
 import xpath from 'xpath';
 
 describe('testapp - source', function () {


### PR DESCRIPTION
Actually just a switch from package `xmldom` to `@xmldom/xmldom`, as in https://github.com/appium/appium-chromedriver/pull/228.

Which resolves the security issue present in latest xmldom version 0.6.0:
https://github.com/xmldom/xmldom/security/advisories/GHSA-5fg8-2547-mr8q

The reason is that the maintainers were forced to switch to a scoped package since 0.7.0:
 https://github.com/xmldom/xmldom/issues/271

I'm one of the xmldom maintainers. Don't hesitate to ask me questions.
I didn't attempt to install and run the project on my machine, but I'm hoping for the CI checks to cover the important things.

<details>
<summary>Changes in xmldom since 0.6.0</summary>
## [0.8.0](https://github.com/xmldom/xmldom/compare/0.7.5...0.8.0)

### Fixed
- Normalize all line endings according to XML specs [1.0](https://w3.org/TR/xml/#sec-line-ends) and [1.1](https://www.w3.org/TR/xml11/#sec-line-ends) \
  BREAKING CHANGE: Certain combination of line break characters are normalized to a single `\n` before parsing takes place and will no longer be preserved.
  - [`#303`](https://github.com/xmldom/xmldom/issues/303) / [`#307`](https://github.com/xmldom/xmldom/pull/307)
  - [`#49`](https://github.com/xmldom/xmldom/issues/49), [`#97`](https://github.com/xmldom/xmldom/issues/97), [`#324`](https://github.com/xmldom/xmldom/issues/324) / [`#314`](https://github.com/xmldom/xmldom/pull/314)
- XMLSerializer: Preserve whitespace character references [`#284`](https://github.com/xmldom/xmldom/issues/284) / [`#310`](https://github.com/xmldom/xmldom/pull/310) \
  BREAKING CHANGE: If you relied on the not spec compliant preservation of literal `\t`, `\n` or `\r` in **attribute values**.
  To preserve those you will have to create XML that instead contains the correct numerical (or hexadecimal) equivalent (e.g. `&#x9;`, `&#xA;`, `&#xD;`).
- Drop deprecated exports `DOMImplementation` and `XMLSerializer` from `lib/dom-parser.js` [#53](https://github.com/xmldom/xmldom/issues/53) / [`#309`](https://github.com/xmldom/xmldom/pull/309)
  BREAKING CHANGE: Use the one provided by the main package export.
- dom: Remove all links as part of `removeChild` [`#343`](https://github.com/xmldom/xmldom/issues/343) / [`#355`](https://github.com/xmldom/xmldom/pull/355)

### Chore
- ci: Restore latest tested node version to 16.x [`#325`](https://github.com/xmldom/xmldom/pull/325)
- ci: Split test and lint steps into jobs [`#111`](https://github.com/xmldom/xmldom/issues/111) / [`#304`](https://github.com/xmldom/xmldom/pull/304)
- Pinned and updated devDependencies

Thank you [@marrus-sh](https://github.com/marrus-sh), [@victorandree](https://github.com/victorandree), [@mdierolf](https://github.com/mdierolf), [@tsabbay](https://github.com/tsabbay), [@fatihpense](https://github.com/fatihpense) for your contributions

## 0.7.5

[Commits](https://github.com/xmldom/xmldom/compare/0.7.4...0.7.5)

### Fixes:

- Preserve default namespace when serializing [`#319`](https://github.com/xmldom/xmldom/issues/319) / [`#321`](https://github.com/xmldom/xmldom/pull/321)
  Thank you [@lupestro](https://github.com/lupestro)

## 0.7.4

[Commits](https://github.com/xmldom/xmldom/compare/0.7.3...0.7.4)

### Fixes:

- Restore ability to parse `__prototype__` attributes [`#315`](https://github.com/xmldom/xmldom/pull/315)
  Thank you [@dsimsonOMF](https://github.com/dsimsonOMF)

## 0.7.3

[Commits](https://github.com/xmldom/xmldom/compare/0.7.2...0.7.3)

### Fixes:

- Add doctype when parsing from string [`#277`](https://github.com/xmldom/xmldom/issues/277) / [`#301`](https://github.com/xmldom/xmldom/pull/301)
- Correct typo in error message [`#294`](https://github.com/xmldom/xmldom/pull/294)
  Thank you [@rrthomas](https://github.com/rrthomas)

### Refactor:

- Improve exports & require statements, new main package entry [`#233`](https://github.com/xmldom/xmldom/pull/233)

### Docs:

- Fix Stryker badge [`#298`](https://github.com/xmldom/xmldom/pull/298)
- Fix link to help-wanted issues [`#299`](https://github.com/xmldom/xmldom/pull/299)

### Chore:

- Execute stryker:dry-run on branches [`#302`](https://github.com/xmldom/xmldom/pull/302)
- Fix stryker config [`#300`](https://github.com/xmldom/xmldom/pull/300)
- Split test and lint scripts [`#297`](https://github.com/xmldom/xmldom/pull/297)
- Switch to stryker dashboard owned by org [`#292`](https://github.com/xmldom/xmldom/pull/292)

## 0.7.2

[Commits](https://github.com/xmldom/xmldom/compare/0.7.1...0.7.2)

### Fixes:

- Types: Add index.d.ts to packaged files [`#288`](https://github.com/xmldom/xmldom/pull/288)
  Thank you [@forty](https://github.com/forty)

## 0.7.1

[Commits](https://github.com/xmldom/xmldom/compare/0.7.0...0.7.1)

### Fixes:

- Types: Copy types from DefinitelyTyped [`#283`](https://github.com/xmldom/xmldom/pull/283)
  Thank you [@kachkaev](https://github.com/kachkaev)

### Chore:
- package.json: remove author, maintainers, etc. [`#279`](https://github.com/xmldom/xmldom/pull/279)

## 0.7.0 

[Commits](https://github.com/xmldom/xmldom/compare/0.6.0...0.7.0)

Due to [`#271`](https://github.com/xmldom/xmldom/issue/271) this version was published as
- unscoped `xmldom` package to github (git tags [`0.7.0`](https://github.com/xmldom/xmldom/tree/0.7.0) and [`0.7.0+unscoped`](https://github.com/xmldom/xmldom/tree/0.7.0%2Bunscoped))
- scoped `@xmldom/xmldom` package to npm (git tag `0.7.0+scoped`)
For more details look at [`#278`](https://github.com/xmldom/xmldom/pull/278#issuecomment-902172483)

### Fixes:

- Security: Misinterpretation of malicious XML input [`CVE-2021-32796`](https://github.com/xmldom/xmldom/security/advisories/GHSA-5fg8-2547-mr8q)
- Implement `Document.getElementsByClassName` as specified [`#213`](https://github.com/xmldom/xmldom/pull/213), thank you [@ChALkeR](https://github.com/ChALkeR)
- Inherit namespace prefix from parent when required [`#268`](https://github.com/xmldom/xmldom/pull/268)
- Handle whitespace in closing tags [`#267`](https://github.com/xmldom/xmldom/pull/267)
- Update `DOMImplementation` according to recent specs [`#210`](https://github.com/xmldom/xmldom/pull/210)  
  BREAKING CHANGE: Only if you "passed features to be marked as available as a constructor arguments" and expected it to "magically work".
- No longer serializes any namespaces with an empty URI [`#244`](https://github.com/xmldom/xmldom/pull/244)   
  (related to [`#168`](https://github.com/xmldom/xmldom/pull/168) released in 0.6.0)  
  BREAKING CHANGE: Only if you rely on ["unsetting" a namespace prefix](https://github.com/xmldom/xmldom/pull/168#issuecomment-886984994) by setting it to an empty string 
- Set `localName` as part of `Document.createElement` [`#229`](https://github.com/xmldom/xmldom/pull/229), thank you [@rrthomas](https://github.com/rrthomas)

### CI

- We are now additionally running tests against node v16
- Stryker tests on the master branch now run against node v14

### Docs

- Describe relations with and between specs: [`#211`](https://github.com/xmldom/xmldom/pull/211), [`#247`](https://github.com/xmldom/xmldom/pull/247)
</details>